### PR TITLE
Add SearchCollectionNavigator to TreeView

### DIFF
--- a/Terminal.Gui/Core/SearchCollectionNavigator.cs
+++ b/Terminal.Gui/Core/SearchCollectionNavigator.cs
@@ -129,5 +129,17 @@ namespace Terminal.Gui {
 			lastKeystroke = DateTime.MinValue;
 
 		}
+
+		/// <summary>
+		/// Returns true if <paramref name="kb"/> is a searchable key
+		/// (e.g. letters, numbers etc) that is valid to pass to to this
+		/// class for search filtering
+		/// </summary>
+		/// <param name="kb"></param>
+		/// <returns></returns>
+		public static bool IsCompatibleKey (KeyEvent kb)
+		{
+			return !kb.IsAlt && !kb.IsCapslock && !kb.IsCtrl && !kb.IsScrolllock && !kb.IsNumlock;
+		}
 	}
 }

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -437,7 +437,7 @@ namespace Terminal.Gui {
 			}
 
 			// Enable user to find & select an item by typing text
-			if (!kb.IsAlt && !kb.IsCapslock && !kb.IsCtrl && !kb.IsScrolllock && !kb.IsNumlock) {
+			if (SearchCollectionNavigator.IsCompatibleKey(kb)) {
 				if (navigator == null) {
 					// BUGBUG: If items change this needs to be recreated.
 					navigator = new SearchCollectionNavigator (source.ToList ().Cast<object> ());

--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -608,6 +608,7 @@ namespace Terminal.Gui {
 
 					if (newIndex != -1) {
 						SelectedObject = map.ElementAt (newIndex).Model;
+						EnsureVisible (selectedObject);
 						SetNeedsDisplay ();
 					}
 

--- a/UnitTests/SearchCollectionNavigatorTests.cs
+++ b/UnitTests/SearchCollectionNavigatorTests.cs
@@ -3,25 +3,41 @@ using Xunit;
 
 namespace Terminal.Gui.Core {
 	public class SearchCollectionNavigatorTests {
+		static string [] simpleStrings = new string []{
+    "appricot", // 0
+    "arm",      // 1
+    "bat",      // 2
+    "batman",   // 3
+    "candle"    // 4
+  };
+		[Fact]
+		public void TestSearchCollectionNavigator_ShouldAcceptNegativeOne ()
+		{
+			var n = new SearchCollectionNavigator (simpleStrings);
+			
+			// Expect that index of -1 (i.e. no selection) should work correctly
+			// and select the first entry of the letter 'b'
+			Assert.Equal (2, n.CalculateNewIndex (-1, 'b'));
+		}
+		[Fact]
+		public void TestSearchCollectionNavigator_OutOfBoundsShouldBeIgnored()
+		{
+			var n = new SearchCollectionNavigator (simpleStrings);
+
+			// Expect saying that index 500 is the current selection should not cause
+			// error and just be ignored (treated as no selection)
+			Assert.Equal (2, n.CalculateNewIndex (500, 'b'));
+		}
 
 		[Fact]
 		public void TestSearchCollectionNavigator_Cycling ()
 		{
-			var strings = new string []{
-    "appricot",
-    "arm",
-    "bat",
-    "batman",
-    "candle"
-  };
-
-			var n = new SearchCollectionNavigator (strings);
+			var n = new SearchCollectionNavigator (simpleStrings);
 			Assert.Equal (2, n.CalculateNewIndex ( 0, 'b'));
 			Assert.Equal (3, n.CalculateNewIndex ( 2, 'b'));
 
 			// if 4 (candle) is selected it should loop back to bat
 			Assert.Equal (2, n.CalculateNewIndex ( 4, 'b'));
-
 		}
 
 


### PR DESCRIPTION
This adds the SearchCollectionNavigator to TreeView.  I have tested it and it seems to work well.  

I've left the old method there since its public (but it is no longer called).  Old method was:

```csharp
AdjustSelectionToNextItemBeginningWith (char character, StringComparison caseSensitivity = StringComparison.CurrentCultureIgnoreCase)
```