### PR TITLE
Correctly mark key as consumed even when index does not change

### DIFF
--- a/Terminal.Gui/Views/TreeView.cs
+++ b/Terminal.Gui/Views/TreeView.cs
@@ -605,14 +605,15 @@ namespace Terminal.Gui {
 					
 					// Find the current selected object within the tree
 					var current = map.IndexOf (b => b.Model == SelectedObject);
-					var newIndex = searchCollectionNavigator.CalculateNewIndex (current, (char)keyEvent.KeyValue);
+					var newIndex = searchCollectionNavigator.CalculateNewIndex (current, (char)keyEvent.KeyValue, out bool foundMatch);
 
 					if (newIndex != current) {
 						SelectedObject = map.ElementAt (newIndex).Model;
 						EnsureVisible (selectedObject);
 						SetNeedsDisplay ();
-						return true;
 					}
+
+					return foundMatch;
 				}
 
 			} finally {


### PR DESCRIPTION
Added out bool foundMatch to `SearchCollectionNavigator.CalculateNewIndex`

This allows `$101` to consume keys even though the index does not change between `$1` and `$10` .  I tried changing to `true` for 'swallow everything' but that broke tab, oops.