### PR TITLE
V1 fixes 2407 toplevel fix

### DIFF
--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -682,15 +682,21 @@ namespace Terminal.Gui {
 			}
 			bool isMenuBarVisible = false, isStatusBarVisible = false;
 			menuBar = null;
+			statusBar = null;
 			if (isTopTop) {
 				isMenuBarVisible = Application.Top.MenuBar?.Visible == true;
 				menuBar = Application.Top.MenuBar;
+				isStatusBarVisible = Application.Top.StatusBar?.Visible == true;
+				statusBar = Application.Top.StatusBar;
 			} else {
 				// It's a Window
 				foreach (var view in parent.Subviews [0].Subviews) {
-					if (view is MenuBar) {
-						isMenuBarVisible = view.Visible;
-						menuBar = (MenuBar)view;
+					if (view is MenuBar mb) {
+						isMenuBarVisible = mb.Visible;
+						menuBar = mb;
+					} else if (view is StatusBar sb) {
+						isStatusBarVisible = sb.Visible;
+						statusBar = sb;
 					}
 				}
 			}
@@ -708,19 +714,7 @@ namespace Terminal.Gui {
 			} else {
 				ny = Math.Min (y, maxLength);
 			}
-			statusBar = null;
-			if (isTopTop) {
-				isStatusBarVisible = Application.Top.StatusBar?.Visible == true;
-				statusBar = Application.Top.StatusBar;
-			} else {
-				// It's a Window
-				foreach (var view in parent.Subviews [0].Subviews) {
-					if (view is StatusBar) {
-						isStatusBarVisible = view.Visible;
-						statusBar = (StatusBar)view;
-					}
-				}
-			}
+
 			if (isTopTop) {
 				maxLength = isStatusBarVisible ? Math.Max (Driver.Rows - 1, superViewFrame.Height - 1)
 					: Math.Max (Driver.Rows, superViewFrame.Height);

--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -221,6 +221,9 @@ namespace Terminal.Gui {
 		{
 			ColorScheme = Colors.TopLevel;
 
+			Application.GrabbingMouse += Application_GrabbingMouse;
+			Application.UnGrabbingMouse += Application_UnGrabbingMouse;
+
 			// TODO: v2 - ALL Views (Responders??!?!) should support the commands related to 
 			//    - Focus
 			//  Move the appropriate AddCommand calls to `Responder`
@@ -258,6 +261,20 @@ namespace Terminal.Gui {
 			AddKeyBinding (Application.AlternateBackwardKey, Command.PreviousViewOrTop); // Needed on Unix
 
 			AddKeyBinding (Key.L | Key.CtrlMask, Command.Refresh);
+		}
+
+		private void Application_UnGrabbingMouse (object sender, GrabMouseEventArgs e)
+		{
+			if (Application.MouseGrabView == this && dragPosition.HasValue) {
+				e.Cancel = true;
+			}
+		}
+
+		private void Application_GrabbingMouse (object sender, GrabMouseEventArgs e)
+		{
+			if (Application.MouseGrabView == this && dragPosition.HasValue) {
+				e.Cancel = true;
+			}
 		}
 
 		/// <summary>
@@ -680,7 +697,7 @@ namespace Terminal.Gui {
 			// ny
 			ny = Math.Max (y, 0);
 			if (isMenuBarVisible && ny < 1) {
-				maxLength =1;
+				maxLength = 1;
 			} else if (!isMenuBarVisible && top._wasMenuAddedBefore) {
 				maxLength = 0;
 			} else {
@@ -889,8 +906,8 @@ namespace Terminal.Gui {
 			}
 
 			if (mouseEvent.Flags.HasFlag (MouseFlags.Button1Released) && dragPosition.HasValue) {
-				Application.UngrabMouse ();
 				dragPosition = null;
+				Application.UngrabMouse ();
 			}
 
 			//System.Diagnostics.Debug.WriteLine ($"dragPosition after: {dragPosition.HasValue}");

--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -650,9 +650,9 @@ namespace Terminal.Gui {
 		/// <param name="y">The target y location.</param>
 		/// <param name="nx">The x location after ensuring <paramref name="top"/> will remain visible.</param>
 		/// <param name="ny">The y location after ensuring <paramref name="top"/> will remain visible.</param>
-		/// <param name="menuBar">The new top most MenuBar (THIS MAKES NO SENSE - Why!?!?)</param>
-		/// <param name="statusBar">The new top most StatusBar(THIS MAKES NO SENSE - Why!?!?)</param>
-		/// <returns>The <see cref="Toplevel"/> that is Application.Top. I CAN FIND NO CODE WHERE THE RETURN IS NOT Application.Top!</returns>
+		/// <param name="menuBar">The new top most MenuBar used by <see cref="PositionToplevel(Toplevel)"/></param>
+		/// <param name="statusBar">The new top most StatusBar used by <see cref="PositionToplevel(Toplevel)"/></param>
+		/// <returns>The <see cref="Toplevel"/> which may could be the Application.Top or another toplevel.</returns>
 		internal View EnsureVisibleBounds (Toplevel top, int x, int y,
 			out int nx, out int ny, out MenuBar menuBar, out StatusBar statusBar)
 		{

--- a/Terminal.Gui/Core/Toplevel.cs
+++ b/Terminal.Gui/Core/Toplevel.cs
@@ -777,7 +777,7 @@ namespace Terminal.Gui {
 				_wasMenuAddedBefore = false;
 			}
 			if (superView != top && (superView == Application.Top || top?.SuperView != null) && ny + top.Frame.Height != superView.Frame.Height - ny - (sb?.Visible == true ? 1 : 0)
-				&& top.Height is Dim.DimFill && (-top.Height.Anchor (0) < 1 || top._initialHeight != null && top.Height.Anchor (0) == top._initialHeight.Anchor (0))) {
+				&& top.Height is Dim.DimFill && (-top.Height.Anchor (0) < 1 || top._initialHeight != null && top.Height.Anchor (0) < top._initialHeight.Anchor (0))) {
 
 				top.Height = Dim.Fill (sb?.Visible == true ? 1 : 0);
 				layoutSubviews = true;

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1351,8 +1351,10 @@ namespace Terminal.Gui {
 			public View View { get; set; }
 		}
 
-		internal Pos _initialX; internal Pos _initialY;
-		internal Dim _initialWidth; internal Dim _initialHeight;
+		internal Pos _initialX { get; private set; }
+		internal Pos _initialY { get; private set; }
+		internal Dim _initialWidth { get; private set; }
+		internal Dim _initialHeight { get; private set; }
 
 		/// <summary>
 		/// Method invoked when a subview is being added to this view.
@@ -1366,10 +1368,10 @@ namespace Terminal.Gui {
 			view.width = view.width ?? view._frame.Width;
 			view.height = view.height ?? view._frame.Height;
 
-			_initialX = view.X;
-			_initialY = view.Y;
-			_initialWidth = view.Width;
-			_initialHeight = view.Height;
+			view._initialX = view.X;
+			view._initialY = view.Y;
+			view._initialWidth = view.Width;
+			view._initialHeight = view.Height;
 
 			view.Added?.Invoke (this);
 		}
@@ -1527,7 +1529,7 @@ namespace Terminal.Gui {
 					}
 					TextFormatter?.Draw (ViewToScreen (Bounds), HasFocus ? GetFocusColor () : GetNormalColor (),
 					    HasFocus ? ColorScheme.HotFocus : GetHotNormalColor (),
-					    containerBounds); 
+					    containerBounds);
 				}
 			}
 

--- a/Terminal.Gui/Core/Window.cs
+++ b/Terminal.Gui/Core/Window.cs
@@ -245,7 +245,17 @@ namespace Terminal.Gui {
 		/// <inheritdoc/>
 		public override void Add (View view)
 		{
-			contentView.Add (view);
+			if (view is MenuBar || view is StatusBar) {
+				if (SuperView is ContentView contentView) {
+					contentView.Add (view);
+				} else if (SuperView == null) {
+					Application.Top.Add (view);
+				} else {
+					SuperView.Add (view);
+				}
+			} else {
+				contentView.Add (view);
+			}
 			if (view.CanFocus) {
 				CanFocus = true;
 			}
@@ -261,7 +271,17 @@ namespace Terminal.Gui {
 			}
 
 			SetNeedsDisplay ();
-			contentView.Remove (view);
+			if (view is MenuBar || view is StatusBar) {
+				if (SuperView is ContentView contentView) {
+					contentView.Remove (view);
+				} else if (SuperView == null) {
+					Application.Top.Remove (view);
+				} else {
+					SuperView.Remove (view);
+				}
+			} else {
+				contentView.Remove (view);
+			}
 
 			if (contentView.InternalSubviews.Count < 1) {
 				CanFocus = false;
@@ -284,6 +304,8 @@ namespace Terminal.Gui {
 			if (!_needsDisplay.IsEmpty || ChildNeedsDisplay || LayoutNeeded) {
 				Driver.SetAttribute (GetNormalColor ());
 				Clear ();
+				LayoutSubviews ();
+				PositionToplevels ();
 				contentView.SetNeedsDisplay ();
 			}
 			var savedClip = contentView.ClipToBounds ();

--- a/UICatalog/Scenarios/Clipping.cs
+++ b/UICatalog/Scenarios/Clipping.cs
@@ -37,7 +37,8 @@ namespace UICatalog.Scenarios {
 				Y = 3,
 				Width = Dim.Fill (3),
 				Height = Dim.Fill (3),
-				ColorScheme = Colors.Dialog
+				ColorScheme = Colors.Dialog,
+				Id = "1"
 			};
 
 			var embedded2 = new Window ("2") {
@@ -45,7 +46,8 @@ namespace UICatalog.Scenarios {
 				Y = 3,
 				Width = Dim.Fill (3),
 				Height = Dim.Fill (3),
-				ColorScheme = Colors.Error
+				ColorScheme = Colors.Error,
+				Id = "2"
 			};
 			embedded1.Add (embedded2);
 
@@ -54,7 +56,8 @@ namespace UICatalog.Scenarios {
 				Y = 3,
 				Width = Dim.Fill (3),
 				Height = Dim.Fill (3),
-				ColorScheme = Colors.TopLevel
+				ColorScheme = Colors.TopLevel,
+				Id = "2"
 			};
 
 			var testButton = new Button (2, 2, "click me");

--- a/UICatalog/Scenarios/Clipping.cs
+++ b/UICatalog/Scenarios/Clipping.cs
@@ -57,7 +57,7 @@ namespace UICatalog.Scenarios {
 				Width = Dim.Fill (3),
 				Height = Dim.Fill (3),
 				ColorScheme = Colors.TopLevel,
-				Id = "2"
+				Id = "3"
 			};
 
 			var testButton = new Button (2, 2, "click me");

--- a/UICatalog/Scenarios/DynamicMenuBar.cs
+++ b/UICatalog/Scenarios/DynamicMenuBar.cs
@@ -436,7 +436,7 @@ namespace UICatalog.Scenarios {
 					}
 
 					if (MenuBar == null) {
-						_menuBar = new MenuBar ();
+						MenuBar = _menuBar = new MenuBar ();
 						Add (_menuBar);
 					}
 					var newMenu = CreateNewMenu (item) as MenuBarItem;
@@ -479,7 +479,7 @@ namespace UICatalog.Scenarios {
 					}
 					if (MenuBar != null && _currentMenuBarItem == null && _menuBar.Menus.Length == 0) {
 						Remove (_menuBar);
-						_menuBar = null;
+						MenuBar = _menuBar = null;
 						DataContext.Menus = new List<DynamicMenuItemList> ();
 						_currentMenuBarItem = null;
 						_currentSelectedMenuBar = -1;

--- a/UICatalog/Scenarios/DynamicStatusBar.cs
+++ b/UICatalog/Scenarios/DynamicStatusBar.cs
@@ -246,21 +246,21 @@ namespace UICatalog.Scenarios {
 				};
 
 				_btnAddStatusBar.Clicked += () => {
-					if (_statusBar != null) {
+					if (StatusBar != null) {
 						return;
 					}
 
-					_statusBar = new StatusBar ();
+					StatusBar = _statusBar = new StatusBar ();
 					Add (_statusBar);
 				};
 
 				_btnRemoveStatusBar.Clicked += () => {
-					if (_statusBar == null) {
+					if (StatusBar == null) {
 						return;
 					}
 
 					Remove (_statusBar);
-					_statusBar = null;
+					StatusBar = _statusBar = null;
 					DataContext.Items = new List<DynamicStatusItemList> ();
 					_currentStatusItem = null;
 					_currentSelectedStatusBar = -1;

--- a/UnitTests/Menus/MenuTests.cs
+++ b/UnitTests/Menus/MenuTests.cs
@@ -1677,8 +1677,8 @@ Edit
 			((FakeDriver)Application.Driver).SetBufferSize (40, 8);
 
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
+ File  Edit                             
 ┌──────────────────────────────────────┐
-│ File  Edit                           │
 │                                      │
 │                                      │
 │                                      │
@@ -1686,50 +1686,50 @@ Edit
 │                                      │
 └──────────────────────────────────────┘", output);
 
-			Assert.True (win.ProcessHotKey (new KeyEvent (Key.F9, new KeyModifiers ())));
-			win.Redraw (win.Bounds);
+			Assert.True (top.ProcessHotKey (new KeyEvent (Key.F9, new KeyModifiers ())));
+			top.Redraw (win.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-┌──────────────────────────────────────┐
-│ File  Edit                           │
-│┌──────┐                              │
-││ New  │                              │
-│└──────┘                              │
+ File  Edit                             
+┌──────┐───────────────────────────────┐
+│ New  │                               │
+└──────┘                               │
+│                                      │
 │                                      │
 │                                      │
 └──────────────────────────────────────┘", output);
 
 			Assert.True (menu.ProcessKey (new KeyEvent (Key.CursorRight, new KeyModifiers ())));
-			win.Redraw (win.Bounds);
+			top.Redraw (win.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-┌──────────────────────────────────────┐
-│ File  Edit                           │
-│      ┌─────────┐                     │
-│      │ Delete ►│                     │
-│      └─────────┘                     │
+ File  Edit                             
+┌─────┌─────────┐──────────────────────┐
+│     │ Delete ►│                      │
+│     └─────────┘                      │
+│                                      │
 │                                      │
 │                                      │
 └──────────────────────────────────────┘", output);
 
 			Assert.True (menu.openMenu.ProcessKey (new KeyEvent (Key.CursorRight, new KeyModifiers ())));
-			win.Redraw (win.Bounds);
+			top.Redraw (win.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-┌──────────────────────────────────────┐
-│ File  Edit                           │
-│      ┌─────────┐                     │
-│      │ Delete ►│┌───────────┐        │
-│      └─────────┘│ All       │        │
-│                 │ Selected  │        │
-│                 └───────────┘        │
+ File  Edit                             
+┌─────┌─────────┐──────────────────────┐
+│     │ Delete ►│┌───────────┐         │
+│     └─────────┘│ All       │         │
+│                │ Selected  │         │
+│                └───────────┘         │
+│                                      │
 └──────────────────────────────────────┘", output);
 
 			Assert.True (menu.openMenu.ProcessKey (new KeyEvent (Key.CursorRight, new KeyModifiers ())));
-			win.Redraw (win.Bounds);
+			top.Redraw (win.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
-┌──────────────────────────────────────┐
-│ File  Edit                           │
-│┌──────┐                              │
-││ New  │                              │
-│└──────┘                              │
+ File  Edit                             
+┌──────┐───────────────────────────────┐
+│ New  │                               │
+└──────┘                               │
+│                                      │
 │                                      │
 │                                      │
 └──────────────────────────────────────┘", output);

--- a/UnitTests/TopLevels/ToplevelTests.cs
+++ b/UnitTests/TopLevels/ToplevelTests.cs
@@ -1264,7 +1264,7 @@ namespace Terminal.Gui.TopLevelTests {
 		}
 
 		[Fact, AutoInitShutdown]
-		public void Toplevel_Inside_ScrollView ()
+		public void Toplevel_Inside_ScrollView_MouseGrabView ()
 		{
 			var scrollView = new ScrollView () {
 				X = 3,
@@ -1301,11 +1301,26 @@ namespace Terminal.Gui.TopLevelTests {
       │                                   ▼
    ◄├──────┤░░░░░░░░░░░░░░░░░░░░░░░░░░░░░► ", output);
 
-			top.EnsureVisibleBounds (win, 6, 6, out int nx, out int ny, out _, out _);
-			Assert.Equal (6, nx);
-			Assert.Equal (6, ny);
-			win.X = nx;
-			win.Y = ny;
+			ReflectionTools.InvokePrivate (
+				typeof (Application),
+				"ProcessMouseEvent",
+				new MouseEvent () {
+					X = 6,
+					Y = 6,
+					Flags = MouseFlags.Button1Pressed
+				});
+			Assert.Equal (win, Application.MouseGrabView);
+			Assert.Equal (new Rect (3, 3, 194, 94), win.Frame);
+
+			ReflectionTools.InvokePrivate (
+				typeof (Application),
+				"ProcessMouseEvent",
+				new MouseEvent () {
+					X = 9,
+					Y = 9,
+					Flags = MouseFlags.Button1Pressed | MouseFlags.ReportMousePosition
+				});
+			Assert.Equal (win, Application.MouseGrabView);
 			top.SetNeedsLayout ();
 			top.LayoutSubviews ();
 			Assert.Equal (new Rect (6, 6, 191, 91), win.Frame);
@@ -1328,11 +1343,15 @@ namespace Terminal.Gui.TopLevelTests {
          │                                ▼
    ◄├──────┤░░░░░░░░░░░░░░░░░░░░░░░░░░░░░► ", output);
 
-			top.EnsureVisibleBounds (win, 2, 2, out nx, out ny, out _, out _);
-			Assert.Equal (2, nx);
-			Assert.Equal (2, ny);
-			win.X = nx;
-			win.Y = ny;
+			ReflectionTools.InvokePrivate (
+				typeof (Application),
+				"ProcessMouseEvent",
+				new MouseEvent () {
+					X = 5,
+					Y = 5,
+					Flags = MouseFlags.Button1Pressed | MouseFlags.ReportMousePosition
+				});
+			Assert.Equal (win, Application.MouseGrabView);
 			top.SetNeedsLayout ();
 			top.LayoutSubviews ();
 			Assert.Equal (new Rect (2, 2, 195, 95), win.Frame);
@@ -1354,6 +1373,26 @@ namespace Terminal.Gui.TopLevelTests {
      │                                    ░
      │                                    ▼
    ◄├──────┤░░░░░░░░░░░░░░░░░░░░░░░░░░░░░► ", output);
+
+			ReflectionTools.InvokePrivate (
+				typeof (Application),
+				"ProcessMouseEvent",
+				new MouseEvent () {
+					X = 5,
+					Y = 5,
+					Flags = MouseFlags.Button1Released
+				});
+			Assert.Null (Application.MouseGrabView);
+
+			ReflectionTools.InvokePrivate (
+				typeof (Application),
+				"ProcessMouseEvent",
+				new MouseEvent () {
+					X = 4,
+					Y = 4,
+					Flags = MouseFlags.ReportMousePosition
+				});
+			Assert.Equal (scrollView, Application.MouseGrabView);
 		}
 	}
 }

--- a/UnitTests/TopLevels/WindowTests.cs
+++ b/UnitTests/TopLevels/WindowTests.cs
@@ -185,24 +185,25 @@ namespace Terminal.Gui.TopLevelTests {
 			top.Add (win);
 			Application.Begin (top);
 			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
-
-			TestHelpers.AssertDriverContentsWithFrameAre (@"
+			var expected = @"
+ File  Edit         
 ┌──────────────────┐
-│ File  Edit       │
+│                  │
 │┌ Frame View ────┐│
 ││                ││
 ││                ││
-││                ││
-││                ││
 │└────────────────┘│
-│ ^Q Quit │ ^O Open│
-└──────────────────┘", output);
+│                  │
+└──────────────────┘
+ ^Q Quit │ ^O Open │";
+			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 
 			((FakeDriver)Application.Driver).SetBufferSize (40, 20);
 
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
+ File  Edit                             
 ┌──────────────────────────────────────┐
-│ File  Edit                           │
+│                                      │
 │┌ Frame View ────────────────────────┐│
 ││                                    ││
 ││                                    ││
@@ -216,26 +217,14 @@ namespace Terminal.Gui.TopLevelTests {
 ││                                    ││
 ││                                    ││
 ││                                    ││
-││                                    ││
-││                                    ││
 │└────────────────────────────────────┘│
-│ ^Q Quit │ ^O Open │ ^C Copy          │
-└──────────────────────────────────────┘", output);
+│                                      │
+└──────────────────────────────────────┘
+ ^Q Quit │ ^O Open │ ^C Copy            ", output);
 
 			((FakeDriver)Application.Driver).SetBufferSize (20, 10);
 
-			TestHelpers.AssertDriverContentsWithFrameAre (@"
-┌──────────────────┐
-│ File  Edit       │
-│┌ Frame View ────┐│
-││                ││
-││                ││
-││                ││
-││                ││
-│└────────────────┘│
-│ ^Q Quit │ ^O Open│
-└──────────────────┘", output);
-
+			TestHelpers.AssertDriverContentsWithFrameAre (expected, output);
 		}
 	}
 }

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -4014,21 +4014,7 @@ This is a tes
 				return true;
 			}
 
-			public void CorrectRedraw (Rect bounds)
-			{
-				// Clear the old and new frame area
-				Clear (_needsDisplay);
-				DrawText ();
-			}
-
-			public void IncorrectRedraw (Rect bounds)
-			{
-				// Clear only the new frame area
-				Clear ();
-				DrawText ();
-			}
-
-			private void DrawText ()
+			public override void Redraw (Rect bounds)
 			{
 				var idx = 0;
 				for (int r = 0; r < Frame.Height; r++) {
@@ -4232,7 +4218,7 @@ cccccccccccccccccccc", output);
 			top.Add (label, view);
 			Application.Begin (top);
 
-			view.CorrectRedraw (view.Bounds);
+			top.Redraw (top.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4240,9 +4226,12 @@ At 0,0
    and also with two lines.  ", output);
 
 			view.Frame = new Rect (1, 1, 10, 1);
+			Assert.Equal (new Rect (1, 1, 10, 1), view.Frame);
+			Assert.Equal (LayoutStyle.Computed, view.LayoutStyle);
+			view.LayoutStyle = LayoutStyle.Absolute;
 			Assert.Equal (new Rect (0, 0, 10, 1), view.Bounds);
-			Assert.Equal (new Rect (1, 1, 31, 3), view._needsDisplay);
-			view.CorrectRedraw (view.Bounds);
+			Assert.Equal (new Rect (0, 0, 10, 1), view._needsDisplay);
+			top.Redraw (top.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0     
  A text wit", output);
@@ -4263,7 +4252,7 @@ At 0,0
 			top.Add (label, view);
 			Application.Begin (top);
 
-			view.CorrectRedraw (view.Bounds);
+			top.Redraw (top.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4276,8 +4265,8 @@ At 0,0
 			view.Height = 1;
 			Assert.Equal (new Rect (1, 1, 10, 1), view.Frame);
 			Assert.Equal (new Rect (0, 0, 10, 1), view.Bounds);
-			Assert.Equal (new Rect (1, 1, 31, 3), view._needsDisplay);
-			view.CorrectRedraw (view.Bounds);
+			Assert.Equal (new Rect (0, 0, 30, 2), view._needsDisplay);
+			top.Redraw (top.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0     
  A text wit", output);
@@ -4298,7 +4287,7 @@ At 0,0
 			top.Add (label, view);
 			Application.Begin (top);
 
-			view.IncorrectRedraw (view.Bounds);
+			view.Redraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4306,9 +4295,12 @@ At 0,0
    and also with two lines.  ", output);
 
 			view.Frame = new Rect (1, 1, 10, 1);
+			Assert.Equal (new Rect (1, 1, 10, 1), view.Frame);
+			Assert.Equal (LayoutStyle.Computed, view.LayoutStyle);
+			view.LayoutStyle = LayoutStyle.Absolute;
 			Assert.Equal (new Rect (0, 0, 10, 1), view.Bounds);
-			Assert.Equal (new Rect (1, 1, 31, 3), view._needsDisplay);
-			view.IncorrectRedraw (view.Bounds);
+			Assert.Equal (new Rect (0, 0, 10, 1), view._needsDisplay);
+			view.Redraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
  A text wit                  
@@ -4331,7 +4323,7 @@ At 0,0
 			top.Add (label, view);
 			Application.Begin (top);
 
-			view.IncorrectRedraw (view.Bounds);
+			view.Redraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4344,8 +4336,8 @@ At 0,0
 			view.Height = 1;
 			Assert.Equal (new Rect (1, 1, 10, 1), view.Frame);
 			Assert.Equal (new Rect (0, 0, 10, 1), view.Bounds);
-			Assert.Equal (new Rect (1, 1, 31, 3), view._needsDisplay);
-			view.IncorrectRedraw (view.Bounds);
+			Assert.Equal (new Rect (0, 0, 30, 2), view._needsDisplay);
+			view.Redraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
  A text wit                  
@@ -4368,7 +4360,6 @@ At 0,0
 			top.Add (label, view);
 			Application.Begin (top);
 
-			view.CorrectRedraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4376,9 +4367,12 @@ At 0,0
    and also with two lines.  ", output);
 
 			view.Frame = new Rect (3, 3, 10, 1);
+			Assert.Equal (new Rect (3, 3, 10, 1), view.Frame);
+			Assert.Equal (LayoutStyle.Computed, view.LayoutStyle);
+			view.LayoutStyle = LayoutStyle.Absolute;
 			Assert.Equal (new Rect (0, 0, 10, 1), view.Bounds);
-			Assert.Equal (new Rect (2, 2, 30, 2), view._needsDisplay);
-			view.CorrectRedraw (view.Bounds);
+			Assert.Equal (new Rect (0, 0, 10, 1), view._needsDisplay);
+			top.Redraw (top.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0       
              
@@ -4401,7 +4395,7 @@ At 0,0
 			top.Add (label, view);
 			Application.Begin (top);
 
-			view.CorrectRedraw (view.Bounds);
+			top.Redraw (top.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4414,8 +4408,8 @@ At 0,0
 			view.Height = 1;
 			Assert.Equal (new Rect (3, 3, 10, 1), view.Frame);
 			Assert.Equal (new Rect (0, 0, 10, 1), view.Bounds);
-			Assert.Equal (new Rect (2, 2, 30, 2), view._needsDisplay);
-			view.CorrectRedraw (view.Bounds);
+			Assert.Equal (new Rect (0, 0, 30, 2), view._needsDisplay);
+			top.Redraw (top.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0       
              
@@ -4438,7 +4432,7 @@ At 0,0
 			top.Add (label, view);
 			Application.Begin (top);
 
-			view.IncorrectRedraw (view.Bounds);
+			view.Redraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4447,8 +4441,8 @@ At 0,0
 
 			view.Frame = new Rect (3, 3, 10, 1);
 			Assert.Equal (new Rect (0, 0, 10, 1), view.Bounds);
-			Assert.Equal (new Rect (2, 2, 30, 2), view._needsDisplay);
-			view.IncorrectRedraw (view.Bounds);
+			Assert.Equal (new Rect (0, 0, 10, 1), view._needsDisplay);
+			view.Redraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4471,7 +4465,7 @@ At 0,0
 			top.Add (label, view);
 			Application.Begin (top);
 
-			view.IncorrectRedraw (view.Bounds);
+			view.Redraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              
@@ -4484,8 +4478,8 @@ At 0,0
 			view.Height = 1;
 			Assert.Equal (new Rect (3, 3, 10, 1), view.Frame);
 			Assert.Equal (new Rect (0, 0, 10, 1), view.Bounds);
-			Assert.Equal (new Rect (2, 2, 30, 2), view._needsDisplay);
-			view.IncorrectRedraw (view.Bounds);
+			Assert.Equal (new Rect (0, 0, 30, 2), view._needsDisplay);
+			view.Redraw (view.Bounds);
 			TestHelpers.AssertDriverContentsWithFrameAre (@"
 At 0,0                       
                              

--- a/UnitTests/Views/ViewTests.cs
+++ b/UnitTests/Views/ViewTests.cs
@@ -1629,6 +1629,10 @@ Y
 			var view = new View (rect);
 			var top = Application.Top;
 			top.Add (view);
+			Assert.Equal ("Pos.Absolute(1)", view._initialX.ToString ());
+			Assert.Equal ("Pos.Absolute(1)", view._initialY.ToString ());
+			Assert.Equal ("Dim.Absolute(10)", view._initialWidth.ToString ());
+			Assert.Equal ("Dim.Absolute(1)", view._initialHeight.ToString ());
 			Assert.Equal (View.Direction.Forward, view.FocusDirection);
 			view.FocusDirection = View.Direction.Backward;
 			Assert.Equal (View.Direction.Backward, view.FocusDirection);
@@ -1669,6 +1673,10 @@ Y
 			view.ViewToScreen (0, 0, out rcol, out rrow);
 			Assert.Equal (-1, rcol);
 			Assert.Equal (-1, rrow);
+			Assert.Equal ("Pos.Absolute(1)", view._initialX.ToString ());
+			Assert.Equal ("Pos.Absolute(1)", view._initialY.ToString ());
+			Assert.Equal ("Dim.Absolute(10)", view._initialWidth.ToString ());
+			Assert.Equal ("Dim.Absolute(1)", view._initialHeight.ToString ());
 		}
 
 		[Fact]


### PR DESCRIPTION
The problem with the existing code with using a `Window` do add a menu and a status bar was because they are added directly to it, instead `Window` handling them by adding to the superview. With this system we can have any number of nested toplevels with menus and scroll bar with adjustments on top and bottom. See the unit test for the nested toplevels. I also fixed all the unit tests failures. If you agree you can change the xml documents because now it's not only the `Application.Top` can handle the menu and status bar adjustments.