### PR TITLE
Tig v2 3338 toplevel must be disposed

### DIFF
--- a/UICatalog/Scenarios/BackgroundWorkerCollection.cs
+++ b/UICatalog/Scenarios/BackgroundWorkerCollection.cs
@@ -18,11 +18,14 @@ public class BackgroundWorkerCollection : Scenario
     {
         var main = Application.Run<OverlappedMain> ();
 
-        //main.Dispose ();
-        Application.Top.Dispose ();
+        main.Dispose ();
+        Application.Shutdown ();
 
 #if DEBUG_IDISPOSABLE
-        Debug.Assert (Application.OverlappedChildren.Count == 0);
+        if (Application.OverlappedChildren is { })
+        {
+            Debug.Assert (Application.OverlappedChildren?.Count == 0);
+        }
 #endif
     }
 


### PR DESCRIPTION
Fix BackgroundWorkerCollection which was causing unit tests failures.