### PR TITLE
V2 3952 test failures fix

### DIFF
--- a/.github/workflows/check-duplicates.yml
+++ b/.github/workflows/check-duplicates.yml
@@ -9,6 +9,6 @@ jobs:
   check-duplicates:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run Duplicate Test Check
       run: powershell -File ./Scripts/FindDuplicateTestMethodsInSameFileName.ps1 -solutionPath "$PWD"

--- a/.github/workflows/check-duplicates.yml
+++ b/.github/workflows/check-duplicates.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run Duplicate Test Check
-      run: powershell -File ./Scripts/FindDuplicateTestMethodsInSameFileName.ps1 -solutionPath "$PWD"
+      run: pwsh -File ./Scripts/FindDuplicateTestMethodsInSameFileName.ps1 -solutionPath "$PWD"

--- a/.github/workflows/check-duplicates.yml
+++ b/.github/workflows/check-duplicates.yml
@@ -1,9 +1,9 @@
 name: Check Duplicate Test Methods
 on:
   push:
-    branches: [ v2-3952_Test_Failures-fix ]
+    branches: [ v2_release, v2_develop ]
   pull_request:
-    branches: [ v2-3952_Test_Failures-fix ]
+    branches: [ v2_release, v2_develop ]
   workflow_dispatch:
 jobs:
   check-duplicates:

--- a/.github/workflows/check-duplicates.yml
+++ b/.github/workflows/check-duplicates.yml
@@ -1,0 +1,14 @@
+name: Check Duplicate Test Methods
+on:
+  push:
+    branches: [ v2-3952_Test_Failures-fix ]
+  pull_request:
+    branches: [ v2-3952_Test_Failures-fix ]
+  workflow_dispatch:
+jobs:
+  check-duplicates:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run Duplicate Test Check
+      run: powershell -File ./Scripts/FindDuplicateTestMethodsInSameFileName.ps1 -solutionPath "$PWD"

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,10 +1,9 @@
-mode: ContinuousDeployment
+workflow: GitFlow/v1
 tag-prefix: '[vV]'
-continuous-delivery-fallback-tag: dev
 branches:
   develop:
     mode: ContinuousDeployment
-    tag: develop
+    label: develop
     regex: v2_develop
     tracks-release-branches: true
     is-source-branch-for: ['main']
@@ -12,14 +11,14 @@ branches:
 
   main:
     mode: ContinuousDeployment
-    tag: prealpha
+    label: prealpha
     regex: v2_release
     is-release-branch: true
     source-branches: ['develop']
 
   v1_develop:
     mode: ContinuousDeployment
-    tag: v1_develop
+    label: v1_develop
     regex: v1_develop
     source-branches:
     - v1_release
@@ -33,9 +32,9 @@ branches:
 
   pull-request:
     mode: ContinuousDeployment
-    tag: PullRequest.{BranchName}
+    label: PullRequest.{BranchName}
     increment: Inherit
-    tag-number-pattern: '[/-](?<number>\d+)'
+    label-number-pattern: '[/-](?<number>\d+)'
     regex: ^(pull|pull\-requests|pr)[/-]
     source-branches:
     - develop
@@ -56,13 +55,13 @@ ignore:
 # branches:
 #   # v1_develop:
 #   #   mode: ContinuousDeployment
-#   #   tag: pre
+#   #   label: pre
 #   #   regex: ^v1_develop?[/-]
 #   #   is-release-branch: false
 #   #   source-branches:
 #   #   - v1
 #   # v1:
-#   #   tag: rc
+#   #   label: rc
 #   #   increment: Patch
 #   #   regex: ^v2?[/-]
 #   #   is-release-branch: false
@@ -71,7 +70,7 @@ ignore:
 
 #   v2_develop:
 #     mode: ContinuousDeployment
-#     tag: pre
+#     label: pre
 #     regex: ^v2_develop?[/-]
 #     is-release-branch: true
 #     tracks-release-branches: true
@@ -80,13 +79,13 @@ ignore:
 #   v2:
 #     mode: ContinuousDeployment
 #     is-release-branch: false
-#     tag: alpha
+#     label: alpha
 #     increment: Patch
 #     regex: ^v2?[/-]
 #     source-branches: ['v2_develop']
 
 #   # feature:
-#   #   tag: useBranchName
+#   #   label: useBranchName
 #   #   regex: ^features?[/-]
 #   #   source-branches:
 #   #   - v1
@@ -95,7 +94,7 @@ ignore:
 #   #   - v2_develop
  
 #   pull-request:
-#     tag: PullRequest.{BranchName}
+#     label: PullRequest.{BranchName}
 #     increment: Inherit
 # ignore:
 #   sha: []

--- a/Scripts/FindDuplicateTestMethodsInSameFileName.ps1
+++ b/Scripts/FindDuplicateTestMethodsInSameFileName.ps1
@@ -1,10 +1,16 @@
 # FindDuplicateTestMethodsInSameFileName.ps1
 param (
-    [string]$solutionPath = "."
+    [string]$solutionPath = ".\Tests"
 )
 
 # Set the base path for relative paths (current directory when script is run)
 $basePath = Get-Location
+
+# Define projects to ignore (add your project names or path patterns here)
+$ignoreProjects = @(
+    "StressTests"
+    # Add more as needed, e.g., "Tests/SubFolder/OldProject"
+)
 
 # Function to extract method names from a C# file
 function Get-TestMethodNames {
@@ -41,6 +47,16 @@ foreach ($group in $fileGroups) {
         $methodMap = @{} # Track methods for this specific filename
 
         foreach ($file in $group.Group) {
+            # Skip files in ignored projects
+            $skipFile = $false
+            foreach ($ignore in $ignoreProjects) {
+                if ($file.FullName -like "*$ignore*") {
+                    $skipFile = $true
+                    break
+                }
+            }
+            if ($skipFile) { continue }
+
             $methods = Get-TestMethodNames -filePath $file.FullName
             foreach ($method in $methods) {
                 if ($methodMap.ContainsKey($method)) {

--- a/Scripts/FindDuplicateTestMethodsInSameFileName.ps1
+++ b/Scripts/FindDuplicateTestMethodsInSameFileName.ps1
@@ -1,0 +1,76 @@
+# FindDuplicateTestMethodsInSameFileName.ps1
+param (
+    [string]$solutionPath = "."
+)
+
+# Set the base path for relative paths (current directory when script is run)
+$basePath = Get-Location
+
+# Function to extract method names from a C# file
+function Get-TestMethodNames {
+    param ($filePath)
+    $content = Get-Content -Path $filePath -Raw
+    $testMethods = @()
+
+    # Match test attributes and capture method names with flexible spacing/comments
+    $methodPattern = '(?s)(\[TestMethod\]|\[Test\]|\[Fact\]|\[Theory\])\s*[\s\S]*?public\s+(?:void|Task)\s+(\w+)\s*\('
+    $methods = [regex]::Matches($content, $methodPattern)
+
+    foreach ($match in $methods) {
+        $methodName = $match.Groups[2].Value  # Group 2 is the method name
+        if ($methodName) {  # Ensure we only add non-empty method names
+            $testMethods += $methodName
+        }
+    }
+    return $testMethods
+}
+
+# Collect all test files
+$testFiles = Get-ChildItem -Path $solutionPath -Recurse -Include *.cs | 
+             Where-Object { $_.FullName -match "Tests" -or $_.FullName -match "Test" }
+
+# Group files by filename
+$fileGroups = $testFiles | Group-Object -Property Name
+
+# Dictionary to track method names and their locations, scoped to same filenames
+$duplicates = @{}
+
+foreach ($group in $fileGroups) {
+    if ($group.Count -gt 1) { # Only process files that exist in multiple locations
+        $fileName = $group.Name
+        $methodMap = @{} # Track methods for this specific filename
+
+        foreach ($file in $group.Group) {
+            $methods = Get-TestMethodNames -filePath $file.FullName
+            foreach ($method in $methods) {
+                if ($methodMap.ContainsKey($method)) {
+                    # Duplicate found for this method in the same filename
+                    if (-not $duplicates.ContainsKey($method)) {
+                        $duplicates[$method] = @($methodMap[$method])
+                    }
+                    $duplicates[$method] += $file.FullName
+                } else {
+                    $methodMap[$method] = $file.FullName
+                }
+            }
+        }
+    }
+}
+
+# Output results with relative paths
+if ($duplicates.Count -eq 0) {
+    Write-Host "No duplicate test method names found in files with the same name across projects." -ForegroundColor Green
+} else {
+    Write-Host "Duplicate test method names found in files with the same name across projects:" -ForegroundColor Yellow
+    foreach ($dup in $duplicates.Keys) {
+        Write-Host "Method: $dup" -ForegroundColor Cyan
+        foreach ($fullPath in $duplicates[$dup]) {
+            $relativePath = Resolve-Path -Path $fullPath -Relative -RelativeBasePath $basePath
+            Write-Host "  - $relativePath" -ForegroundColor White
+        }
+    }
+    # Display total number of duplicate methods
+    Write-Host "Total number of duplicate methods: $($duplicates.Count)" -ForegroundColor Magenta
+    # Fail the pipeline by setting a non-zero exit code
+    exit 1
+}

--- a/Scripts/FindDuplicateTestMethodsInSameFileName.ps1
+++ b/Scripts/FindDuplicateTestMethodsInSameFileName.ps1
@@ -4,24 +4,7 @@ param (
 )
 
 # Set the base path for relative paths (current directory when script is run)
-$basePath = Get-Location | Select-Object -ExpandProperty Path
-
-# Function to get relative path (compatible with PowerShell 5.1)
-function Get-RelativePath {
-    param (
-        [string]$basePath,
-        [string]$fullPath
-    )
-    # Ensure paths are absolute and normalized
-    $basePath = [System.IO.Path]::GetFullPath($basePath)
-    $fullPath = [System.IO.Path]::GetFullPath($fullPath)
-    # Calculate relative path using .NET
-    if ($fullPath.StartsWith($basePath)) {
-        $relative = $fullPath.Substring($basePath.Length).TrimStart('\', '/')
-        return $relative
-    }
-    return $fullPath  # Fallback to full path if not relative
-}
+$basePath = Get-Location
 
 # Function to extract method names from a C# file
 function Get-TestMethodNames {
@@ -29,12 +12,13 @@ function Get-TestMethodNames {
     $content = Get-Content -Path $filePath -Raw
     $testMethods = @()
 
+    # Match test attributes and capture method names with flexible spacing/comments
     $methodPattern = '(?s)(\[TestMethod\]|\[Test\]|\[Fact\]|\[Theory\])\s*[\s\S]*?public\s+(?:void|Task)\s+(\w+)\s*\('
     $methods = [regex]::Matches($content, $methodPattern)
 
     foreach ($match in $methods) {
-        $methodName = $match.Groups[2].Value
-        if ($methodName) {
+        $methodName = $match.Groups[2].Value  # Group 2 is the method name
+        if ($methodName) {  # Ensure we only add non-empty method names
             $testMethods += $methodName
         }
     }
@@ -52,14 +36,15 @@ $fileGroups = $testFiles | Group-Object -Property Name
 $duplicates = @{}
 
 foreach ($group in $fileGroups) {
-    if ($group.Count -gt 1) {
+    if ($group.Count -gt 1) { # Only process files that exist in multiple locations
         $fileName = $group.Name
-        $methodMap = @{}
+        $methodMap = @{} # Track methods for this specific filename
 
         foreach ($file in $group.Group) {
             $methods = Get-TestMethodNames -filePath $file.FullName
             foreach ($method in $methods) {
                 if ($methodMap.ContainsKey($method)) {
+                    # Duplicate found for this method in the same filename
                     if (-not $duplicates.ContainsKey($method)) {
                         $duplicates[$method] = @($methodMap[$method])
                     }
@@ -80,10 +65,12 @@ if ($duplicates.Count -eq 0) {
     foreach ($dup in $duplicates.Keys) {
         Write-Host "Method: $dup" -ForegroundColor Cyan
         foreach ($fullPath in $duplicates[$dup]) {
-            $relativePath = Get-RelativePath -basePath $basePath -fullPath $fullPath
+            $relativePath = Resolve-Path -Path $fullPath -Relative -RelativeBasePath $basePath
             Write-Host "  - $relativePath" -ForegroundColor White
         }
     }
+    # Display total number of duplicate methods
     Write-Host "Total number of duplicate methods: $($duplicates.Count)" -ForegroundColor Magenta
+    # Fail the pipeline by setting a non-zero exit code
     exit 1
 }

--- a/Terminal.sln
+++ b/Terminal.sln
@@ -31,6 +31,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{13BB2C46-B324-4B9C-92EB-CE6184D4736E}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\api-docs.yml = .github\workflows\api-docs.yml
+		.github\workflows\check-duplicates.yml = .github\workflows\check-duplicates.yml
 		GitVersion.yml = GitVersion.yml
 		.github\workflows\integration-tests.yml = .github\workflows\integration-tests.yml
 		.github\workflows\publish.yml = .github\workflows\publish.yml


### PR DESCRIPTION
I also changed the `GitVersion.yml` file to be compatible to the current version 6.1.0.
If you want to run the GitHub Actions for the `check-duplicates.yml` file in your fork change to this `branches: [ v2-3952_Test_Failures ]`.