### PR TITLE
Fix default button from raise without mouse clicked

### DIFF
--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -145,7 +145,7 @@ public partial class View // Command APIs
         // Accept is a special case where if the event is not canceled, the event is
         //  - Invoked on any peer-View with IsDefault == true
         //  - bubbled up the SuperView hierarchy.
-        if (!args.Handled)
+        if (!args.Handled && ctx is not CommandContext<MouseBinding>)
         {
             // If there's an IsDefault peer view in SubViews, try it
             View? isDefaultView = SuperView?.InternalSubViews.FirstOrDefault (v => v is Button { IsDefault: true });

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -97,9 +97,14 @@ public class Button : View, IDesignable
         // TODO: If `IsDefault` were a property on `View` *any* View could work this way. That's theoretical as
         // TODO: no use-case has been identified for any View other than Button to act like this.
         // If Accept was not handled...
-        if (cachedIsDefault && SuperView is { })
+        if (commandContext is not CommandContext<MouseBinding> && cachedIsDefault && SuperView is { })
         {
             return SuperView.InvokeCommand (Command.Accept);
+        }
+
+        if (commandContext is CommandContext<MouseBinding> { Binding.MouseEventArgs: { } } context && context.Binding.MouseEventArgs.View == this)
+        {
+            return true;
         }
 
         return false;

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -701,11 +701,11 @@ public class ButtonTests (ITestOutputHelper output)
     {
         var acceptOk = 0;
         var acceptCancel = 0;
-        Button btnOk = new () { Id = "Ok", Text = "Ok", IsDefault = true };
+        Button btnOk = new () { Id = "Ok", Text = "_Ok", IsDefault = true };
         btnOk.Accepting += (s, e) => acceptOk++;
-        Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "Cancel" };
+        Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "_Cancel" };
         btnCancel.Accepting += (s, e) => acceptCancel++;
-        Application.Top = new Toplevel ();
+        Application.Top = new ();
         Application.Top.Add (btnOk, btnCancel);
         var rs = Application.Begin (Application.Top);
 

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -701,7 +701,7 @@ public class ButtonTests (ITestOutputHelper output)
     {
         var acceptOk = 0;
         var acceptCancel = 0;
-        Button btnOk = new () { Id = "Ok", Text = "_Ok", IsDefault = true };
+        Button btnOk = new () { Id = "Ok", Text = "_Ok", IsDefaultAcceptView = true };
         btnOk.Accepting += (s, e) => acceptOk++;
         Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "_Cancel" };
         btnCancel.Accepting += (s, e) => acceptCancel++;

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -714,5 +714,7 @@ public class ButtonTests (ITestOutputHelper output)
         Assert.Equal (1, acceptCancel);
 
         Application.End (rs);
+        Application.Top.Dispose ();
+        Application.ResetState ();
     }
 }

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -694,4 +694,26 @@ public class ButtonTests (ITestOutputHelper output)
 
         button.Dispose ();
     }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void MouseClick_From_Non_Default_Button_Raise_Accept_In_The_Default_Button ()
+    {
+        var acceptOk = 0;
+        var acceptCancel = 0;
+        Button btnOk = new () { Id = "Ok", Text = "Ok", IsDefault = true };
+        btnOk.Accepting += (s, e) => acceptOk++;
+        Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "Cancel" };
+        btnCancel.Accepting += (s, e) => acceptCancel++;
+        Application.Top = new Toplevel ();
+        Application.Top.Add (btnOk, btnCancel);
+        var rs = Application.Begin (Application.Top);
+
+        Application.RaiseMouseEvent (new () { ScreenPosition = new (0, 1), Flags = MouseFlags.Button1Clicked });
+        Application.RunIteration (ref rs);
+        Assert.Equal (0, acceptOk);
+        Assert.Equal (1, acceptCancel);
+
+        Application.End (rs);
+    }
 }

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -710,7 +710,6 @@ public class ButtonTests (ITestOutputHelper output)
         var rs = Application.Begin (Application.Top);
 
         Application.RaiseMouseEvent (new () { ScreenPosition = new (0, 1), Flags = MouseFlags.Button1Clicked });
-        Application.RunIteration (ref rs);
         Assert.Equal (0, acceptOk);
         Assert.Equal (1, acceptCancel);
 


### PR DESCRIPTION
## Fixes

- Fixes #_____

## Proposed Changes/Todos

- [x] Fixes a default button raising accepting when another button was mouse clicked

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
