### PR TITLE
Fixes #4170. Button.IsDefault is confusing

### DIFF
--- a/Examples/UICatalog/Scenarios/Dialogs.cs
+++ b/Examples/UICatalog/Scenarios/Dialogs.cs
@@ -182,21 +182,21 @@ public class Dialogs : Scenario
             X = Pos.Center (), Y = Pos.Bottom (frame) + 2, IsDefaultAcceptView = true, Text = "_Show Dialog"
         };
 
-        app.Accepting += (s, e) =>
-                                   {
-                                       Dialog dlg = CreateDemoDialog (
-                                                                      widthEdit,
-                                                                      heightEdit,
-                                                                      titleEdit,
-                                                                      numButtonsEdit,
-                                                                      glyphsNotWords,
-                                                                      alignmentGroup,
-                                                                      buttonPressedLabel
-                                                                     );
-                                       Application.Run (dlg);
-                                       dlg.Dispose ();
-                                       e.Handled = true;
-                                   };
+        showDialogButton.Accepting += (s, e) =>
+                                      {
+                                          Dialog dlg = CreateDemoDialog (
+                                                                         widthEdit,
+                                                                         heightEdit,
+                                                                         titleEdit,
+                                                                         numButtonsEdit,
+                                                                         glyphsNotWords,
+                                                                         alignmentGroup,
+                                                                         buttonPressedLabel
+                                                                        );
+                                          Application.Run (dlg);
+                                          dlg.Dispose ();
+                                          e.Handled = true;
+                                      };
 
         app.Add (showDialogButton);
 

--- a/Examples/UICatalog/Scenarios/FileDialogExamples.cs
+++ b/Examples/UICatalog/Scenarios/FileDialogExamples.cs
@@ -128,7 +128,7 @@ public class FileDialogExamples : Scenario
 
         var btn = new Button { X = 1, Y = 9, IsDefaultAcceptView = true, Text = "Run Dialog" };
 
-        win.Accepting += (s, e) =>
+        btn.Accepting += (s, e) =>
                         {
                             try
                             {
@@ -137,10 +137,6 @@ public class FileDialogExamples : Scenario
                             catch (Exception ex)
                             {
                                 MessageBox.ErrorQuery ("Error", ex.ToString (), "_Ok");
-                            }
-                            finally
-                            {
-                                e.Handled = true;
                             }
                         };
         win.Add (btn);

--- a/Examples/UICatalog/Scenarios/MessageBoxes.cs
+++ b/Examples/UICatalog/Scenarios/MessageBoxes.cs
@@ -20,6 +20,7 @@ public class MessageBoxes : Scenario
 
         var frame = new FrameView
         {
+            TabStop = TabBehavior.TabStop, // FrameView normally sets to TabGroup
             X = Pos.Center (),
             Y = 1,
             Width = Dim.Percent (75),

--- a/Examples/UICatalog/Scenarios/MessageBoxes.cs
+++ b/Examples/UICatalog/Scenarios/MessageBoxes.cs
@@ -231,56 +231,56 @@ public class MessageBoxes : Scenario
             X = Pos.Center (), Y = Pos.Bottom (frame) + 2, IsDefaultAcceptView = true, Text = "_Show MessageBox"
         };
 
-        app.Accepting += (s, e) =>
-                                       {
-                                           try
-                                           {
-                                               int width = int.Parse (widthEdit.Text);
-                                               int height = int.Parse (heightEdit.Text);
-                                               int numButtons = int.Parse (numButtonsEdit.Text);
-                                               int defaultButton = int.Parse (defaultButtonEdit.Text);
+        showMessageBoxButton.Accepting += (s, e) =>
+                                          {
+                                              try
+                                              {
+                                                  int width = int.Parse (widthEdit.Text);
+                                                  int height = int.Parse (heightEdit.Text);
+                                                  int numButtons = int.Parse (numButtonsEdit.Text);
+                                                  int defaultButton = int.Parse (defaultButtonEdit.Text);
 
-                                               List<string> btns = new ();
+                                                  List<string> btns = new ();
 
-                                               for (var i = 0; i < numButtons; i++)
-                                               {
-                                                   btns.Add ($"_{NumberToWords.Convert (i)}");
-                                               }
+                                                  for (var i = 0; i < numButtons; i++)
+                                                  {
+                                                      btns.Add ($"_{NumberToWords.Convert (i)}");
+                                                  }
 
-                                               if (styleRadioGroup.SelectedItem == 0)
-                                               {
-                                                   buttonPressedLabel.Text =
-                                                       $"{MessageBox.Query (
-                                                                             width,
-                                                                             height,
-                                                                             titleEdit.Text,
-                                                                             messageEdit.Text,
-                                                                             defaultButton,
-                                                                             ckbWrapMessage.CheckedState == CheckState.Checked,
-                                                                             btns.ToArray ()
-                                                                            )}";
-                                               }
-                                               else
-                                               {
-                                                   buttonPressedLabel.Text =
-                                                       $"{MessageBox.ErrorQuery (
-                                                                                  width,
-                                                                                  height,
-                                                                                  titleEdit.Text,
-                                                                                  messageEdit.Text,
-                                                                                  defaultButton,
-                                                                                  ckbWrapMessage.CheckedState == CheckState.Checked,
-                                                                                  btns.ToArray ()
-                                                                                 )}";
-                                               }
-                                           }
-                                           catch (FormatException)
-                                           {
-                                               buttonPressedLabel.Text = "Invalid Options";
-                                           }
+                                                  if (styleRadioGroup.SelectedItem == 0)
+                                                  {
+                                                      buttonPressedLabel.Text =
+                                                          $"{MessageBox.Query (
+                                                                               width,
+                                                                               height,
+                                                                               titleEdit.Text,
+                                                                               messageEdit.Text,
+                                                                               defaultButton,
+                                                                               ckbWrapMessage.CheckedState == CheckState.Checked,
+                                                                               btns.ToArray ()
+                                                                              )}";
+                                                  }
+                                                  else
+                                                  {
+                                                      buttonPressedLabel.Text =
+                                                          $"{MessageBox.ErrorQuery (
+                                                                                    width,
+                                                                                    height,
+                                                                                    titleEdit.Text,
+                                                                                    messageEdit.Text,
+                                                                                    defaultButton,
+                                                                                    ckbWrapMessage.CheckedState == CheckState.Checked,
+                                                                                    btns.ToArray ()
+                                                                                   )}";
+                                                  }
+                                              }
+                                              catch (FormatException)
+                                              {
+                                                  buttonPressedLabel.Text = "Invalid Options";
+                                              }
 
-                                           e.Handled = true;
-                                       };
+                                              e.Handled = true;
+                                          };
         app.Add (showMessageBoxButton);
 
         app.Add (buttonPressedLabel);

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -142,6 +142,12 @@ public partial class View // Command APIs
             Accepting?.Invoke (this, args);
         }
 
+        // Let's IDefaultAcceptView handle the Accept command
+        if (this is IDefaultAcceptView)
+        {
+            return args.Handled;
+        }
+
         // Accept is a special case where if the event is not canceled, the event is
         //  - Invoked on any peer-View where IDefaultAcceptView.GetIsDefaultAcceptView() returns true
         //  - propagated up the SuperView hierarchy.
@@ -150,11 +156,10 @@ public partial class View // Command APIs
             // If there's a default accept view peer view in SubViews, try it
             View? defaultAcceptView = SuperView?.InternalSubViews.FirstOrDefault (v => v is IDefaultAcceptView defaultAccept && defaultAccept.GetIsDefaultAcceptView ());
 
-            if (defaultAcceptView != this && defaultAcceptView is IDefaultAcceptView defaultAccept && defaultAccept.GetIsDefaultAcceptView ())
+            if (defaultAcceptView is { } && defaultAcceptView != this)
             {
-
                 Logging.Debug ($"{Title} ({ctx?.Source?.Title}) - InvokeCommand on Default Accept View ({defaultAcceptView?.Title})");
-                bool? handled = defaultAcceptView?.InvokeCommand (Command.Accept, ctx);
+                bool? handled = defaultAcceptView?.OnDefaultAcceptView (args);
 
                 if (handled == true)
                 {
@@ -172,6 +177,16 @@ public partial class View // Command APIs
 
         return args.Handled;
     }
+
+    /// <summary>
+    /// Called when the View acts as the default handler for the <see cref="Command.Accept"/> command.
+    /// </summary>
+    /// <param name="args">The event arguments containing context about the command invocation.</param>
+    /// <returns>
+    /// <see langword="true"/> to indicate the event was handled and processing should stop.
+    /// <see langword="false"/> to indicate the event was not handled and processing should continue.
+    /// </returns>
+    protected virtual bool OnDefaultAcceptView(CommandEventArgs args) { return false; }
 
     /// <summary>
     ///     When a View implements this interface, it will act as the default handler for <see cref="Command.Accept"/>.

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -130,41 +130,26 @@ public partial class View // Command APIs
         Logging.Debug ($"{Title} ({ctx?.Source?.Title})");
         CommandEventArgs args = new () { Context = ctx };
 
-        // Best practice is to invoke the virtual method first.
-        // This allows derived classes to handle the event and potentially cancel it.
-        //Logging.Debug ($"{Title} ({ctx?.Source?.Title}) - Calling OnAccepting...");
-        args.Handled = OnAccepting (args) || args.Handled;
+        // Best practice is to invoke the event first
+        // otherwise this method would not be called.
+        // Raise the event to notify any external subscribers.
+        Accepting?.Invoke (this, args);
 
-        if (!args.Handled && Accepting is { })
-        {
-            // If the event is not canceled by the virtual method, raise the event to notify any external subscribers.
-            //Logging.Debug ($"{Title} ({ctx?.Source?.Title}) - Raising Accepting...");
-            Accepting?.Invoke (this, args);
-        }
-
-        // Let's IDefaultAcceptView handle the Accept command
-        if (this is IDefaultAcceptView)
-        {
-            return args.Handled;
-        }
-
-        // Accept is a special case where if the event is not canceled, the event is
-        //  - Invoked on any peer-View where IDefaultAcceptView.GetIsDefaultAcceptView() returns true
-        //  - propagated up the SuperView hierarchy.
         if (!args.Handled)
         {
-            // If there's a default accept view peer view in SubViews, try it
-            View? defaultAcceptView = SuperView?.InternalSubViews.FirstOrDefault (v => v is IDefaultAcceptView defaultAccept && defaultAccept.GetIsDefaultAcceptView ());
-
-            if (defaultAcceptView is { } && defaultAcceptView != this)
+            // This allows derived classes to handle the event if not handled by the Accepting event.
+            //Logging.Debug ($"{Title} ({ctx?.Source?.Title}) - Calling OnAccepting...");
+            if (OnAccepting (args))
             {
-                Logging.Debug ($"{Title} ({ctx?.Source?.Title}) - InvokeCommand on Default Accept View ({defaultAcceptView?.Title})");
-                bool? handled = defaultAcceptView?.OnDefaultAcceptView (args);
+                return true;
+            }
 
-                if (handled == true)
-                {
-                    return true;
-                }
+            // Accept is a special case where if the event is not canceled, the event is
+            //  - Invoked on any peer-View where IDefaultAcceptView.GetIsDefaultAcceptView() returns true
+            //  - propagated up the SuperView hierarchy.
+            if (GetDefaultAcceptView (ctx))
+            {
+                return true;
             }
 
             if (SuperView is { })
@@ -178,15 +163,33 @@ public partial class View // Command APIs
         return args.Handled;
     }
 
-    /// <summary>
-    /// Called when the View acts as the default handler for the <see cref="Command.Accept"/> command.
-    /// </summary>
-    /// <param name="args">The event arguments containing context about the command invocation.</param>
-    /// <returns>
-    /// <see langword="true"/> to indicate the event was handled and processing should stop.
-    /// <see langword="false"/> to indicate the event was not handled and processing should continue.
-    /// </returns>
-    protected virtual bool OnDefaultAcceptView(CommandEventArgs args) { return false; }
+    internal bool GetDefaultAcceptView (ICommandContext? ctx)
+    {
+        var superView = SuperView;
+
+        while (superView is { })
+        {
+            // If there's a default accept view peer view in SubViews, try it
+            View? defaultAcceptView = superView?.InternalSubViews.FirstOrDefault (v => v is IDefaultAcceptView defaultAccept && defaultAccept.GetIsDefaultAcceptView ());
+
+            if (defaultAcceptView is { } && defaultAcceptView != this)
+            {
+                Logging.Debug ($"{Title} ({ctx?.Source?.Title}) - InvokeCommand on Default Accept View ({defaultAcceptView?.Title})");
+                bool? handled = defaultAcceptView?.InvokeCommand (Command.Accept, ctx);
+
+                if (handled == true)
+                {
+                    return true;
+                }
+
+                break;
+            }
+
+            superView = superView?.SuperView;
+        }
+
+        return false;
+    }
 
     /// <summary>
     ///     When a View implements this interface, it will act as the default handler for <see cref="Command.Accept"/>.

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -83,6 +83,14 @@ public class Button : View, IDesignable, IDefaultAcceptView
 
     private bool? HandleAcceptCommand (ICommandContext commandContext)
     {
+        if (commandContext is CommandContext<KeyBinding>
+            && IsDefaultAcceptView
+            && ((commandContext.Command == Command.Accept && !IsDefaultAccept)
+                || (commandContext.Command == Command.Quit && !IsDefaultCancel)))
+        {
+            return false;
+        }
+
         if (RaiseActivating (commandContext) is true)
         {
             return true;
@@ -110,7 +118,7 @@ public class Button : View, IDesignable, IDefaultAcceptView
 
         if (HasFocus || cachedIsDefault || (args.Context is CommandContext<MouseBinding> { Binding.MouseEventArgs: { } } context && context.Binding.MouseEventArgs.View == this))
         {
-            if (args.Context?.Command == Command.Quit)
+            if (args.Context?.Command == Command.Quit && QuitOnDefaultCancel)
             {
                 Application.RequestStop ();
             }
@@ -182,8 +190,135 @@ public class Button : View, IDesignable, IDefaultAcceptView
 
         _isDefaultAcceptView = value;
 
+        if (value && !IsDefaultCancel && !QuitOnDefaultCancel)
+        {
+            IsDefaultAccept = true;
+            QuitOnDefaultCancel = false;
+        }
+
+        if (!value)
+        {
+            IsDefaultAccept = false;
+            IsDefaultCancel = false;
+            QuitOnDefaultCancel = false;
+        }
+
         UpdateTextFormatterText ();
         SetNeedsLayout ();
+    }
+
+    private bool _isDefaultAccept;
+
+    /// <summary>
+    ///     Gets or sets whether this Button is the default accept button for the View.
+    /// </summary>
+    public bool IsDefaultAccept
+    {
+        get => _isDefaultAccept;
+        set => SetIsDefaultAccept (value);
+    }
+
+    private void SetIsDefaultAccept (bool value)
+    {
+        if (_isDefaultAccept == value)
+        {
+            return;
+        }
+
+        _isDefaultAccept = value;
+
+        if (value && !IsDefaultAcceptView)
+        {
+            IsDefaultAcceptView = true;
+        }
+
+        if (!value && IsDefaultAcceptView)
+        {
+            _isDefaultCancel = true;
+        }
+
+        if (value && IsDefaultCancel)
+        {
+            _isDefaultCancel = false;
+        }
+
+        if (value && QuitOnDefaultCancel)
+        {
+            _quitOnDefaultCancel = false;
+        }
+    }
+
+    private bool _isDefaultCancel;
+
+    /// <summary>
+    ///     Gets or sets whether this Button is the default cancel button for the View.
+    /// </summary>
+    public bool IsDefaultCancel
+    {
+        get => _isDefaultCancel;
+        set => SetIsDefaultCancel (value);
+    }
+
+    private void SetIsDefaultCancel (bool value)
+    {
+        if (_isDefaultCancel == value)
+        {
+            return;
+        }
+
+        _isDefaultCancel = value;
+
+        if (value && !IsDefaultAcceptView)
+        {
+            IsDefaultAcceptView = true;
+            _quitOnDefaultCancel = true;
+        }
+
+        if (!value && IsDefaultAcceptView)
+        {
+            _isDefaultAccept = true;
+            _quitOnDefaultCancel = false;
+        }
+
+        if (value && IsDefaultAccept)
+        {
+            _isDefaultAccept = false;
+            _quitOnDefaultCancel = true;
+        }
+    }
+
+    private bool _quitOnDefaultCancel;
+
+    /// <summary>
+    ///     Gets or sets whether the application will quit when the default cancel button is pressed.
+    /// </summary>
+    public bool QuitOnDefaultCancel
+    {
+        get => _quitOnDefaultCancel;
+        set => SetQuitOnDefaultCancel (value);
+    }
+
+    private void SetQuitOnDefaultCancel (bool value)
+    {
+        if (_quitOnDefaultCancel == value)
+        {
+            return;
+        }
+
+        _quitOnDefaultCancel = value;
+
+        if (value && !IsDefaultAcceptView)
+        {
+            IsDefaultAcceptView = true;
+            _isDefaultAccept = false;
+            _isDefaultCancel = true;
+        }
+
+        if (value && IsDefaultAcceptView)
+        {
+            _isDefaultAccept = false;
+            _isDefaultCancel = true;
+        }
     }
 
     /// <summary>

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -83,8 +83,6 @@ public class Button : View, IDesignable, IDefaultAcceptView
 
     private bool? HandleAcceptCommand (ICommandContext commandContext)
     {
-        bool cachedIsDefault = IsDefaultAcceptView; // Supports "Swap Default" in Buttons scenario where IsDefaultAcceptView changes
-
         if (RaiseActivating (commandContext) is true)
         {
             return true;
@@ -95,48 +93,32 @@ public class Button : View, IDesignable, IDefaultAcceptView
             SetFocus ();
         }
 
-        if (RaiseAccepting (commandContext) is true)
-        {
-            return true;
-        }
-
-        if (HasFocus || cachedIsDefault || (commandContext is CommandContext<MouseBinding> { Binding.MouseEventArgs: { } } context && context.Binding.MouseEventArgs.View == this))
-        {
-            return true;
-        }
-
-        return false;
+        return RaiseAccepting (commandContext);
     }
 
     private bool? HandleQuitKeyCommand (ICommandContext commandContext)
     {
         // If there's a default accept view peer view in SubViews, try it
-        View? defaultAcceptView = SuperView?.InternalSubViews.FirstOrDefault (v => v is IDefaultAcceptView defaultAccept && defaultAccept.GetIsDefaultAcceptView ());
-
-        if (defaultAcceptView != this)
-        {
-            bool? handled = defaultAcceptView?.InvokeCommand (Command.Accept, commandContext);
-
-            if (handled == true)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return GetDefaultAcceptView (commandContext);
     }
 
-    /// <inheritdoc/>
-    protected override bool OnDefaultAcceptView (CommandEventArgs args)
+    /// <inheritdoc />
+    protected override bool OnAccepting (CommandEventArgs args)
     {
-        bool? handled = InvokeCommand (Command.Accept, args.Context);
+        // The event wasn't handled, so we can handle it here.
+        bool cachedIsDefault = IsDefaultAcceptView; // Supports "Swap Default" in Buttons scenario where IsDefaultAcceptView changes
 
-        if (handled == true)
+        if (HasFocus || cachedIsDefault || (args.Context is CommandContext<MouseBinding> { Binding.MouseEventArgs: { } } context && context.Binding.MouseEventArgs.View == this))
         {
+            if (args.Context?.Command == Command.Quit)
+            {
+                Application.RequestStop ();
+            }
+
             return true;
         }
 
-        return base.OnDefaultAcceptView (args);
+        return false;
     }
 
     /// <inheritdoc />

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -59,17 +59,20 @@ public class Button : View, IDesignable, IDefaultAcceptView
 
         CanFocus = true;
 
-        AddCommand (Command.HotKey, HandleHotKeyCommand);
+        AddCommand (Command.Accept, HandleAcceptCommand);
+        AddCommand (Command.Quit, HandleQuitKeyCommand);
 
         KeyBindings.Remove (Key.Space);
-        KeyBindings.Add (Key.Space, Command.HotKey);
+        KeyBindings.Add (Key.Space, Command.Accept);
         KeyBindings.Remove (Key.Enter);
-        KeyBindings.Add (Key.Enter, Command.HotKey);
+        KeyBindings.Add (Key.Enter, Command.Accept);
+        KeyBindings.Remove (Key.Esc);
+        KeyBindings.Add (Key.Esc, Command.Quit);
 
-        MouseBindings.ReplaceCommands (MouseFlags.Button1Clicked, Command.HotKey);
-        MouseBindings.ReplaceCommands (MouseFlags.Button2Clicked, Command.HotKey);
-        MouseBindings.ReplaceCommands (MouseFlags.Button3Clicked, Command.HotKey);
-        MouseBindings.ReplaceCommands (MouseFlags.Button4Clicked, Command.HotKey);
+        MouseBindings.ReplaceCommands (MouseFlags.Button1Clicked, Command.Accept);
+        MouseBindings.ReplaceCommands (MouseFlags.Button2Clicked, Command.Accept);
+        MouseBindings.ReplaceCommands (MouseFlags.Button3Clicked, Command.Accept);
+        MouseBindings.ReplaceCommands (MouseFlags.Button4Clicked, Command.Accept);
 
         TitleChanged += Button_TitleChanged;
         //MouseClick += Button_MouseClick;
@@ -78,7 +81,7 @@ public class Button : View, IDesignable, IDefaultAcceptView
         HighlightStates = DefaultHighlightStates;
     }
 
-    private bool? HandleHotKeyCommand (ICommandContext commandContext)
+    private bool? HandleAcceptCommand (ICommandContext commandContext)
     {
         bool cachedIsDefault = IsDefaultAcceptView; // Supports "Swap Default" in Buttons scenario where IsDefaultAcceptView changes
 
@@ -87,25 +90,63 @@ public class Button : View, IDesignable, IDefaultAcceptView
             return true;
         }
 
-        bool? handled = RaiseAccepting (commandContext);
+        if (!HasFocus)
+        {
+            SetFocus ();
+        }
+
+        if (RaiseAccepting (commandContext) is true)
+        {
+            return true;
+        }
+
+        if (HasFocus || cachedIsDefault || (commandContext is CommandContext<MouseBinding> { Binding.MouseEventArgs: { } } context && context.Binding.MouseEventArgs.View == this))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool? HandleQuitKeyCommand (ICommandContext commandContext)
+    {
+        // If there's a default accept view peer view in SubViews, try it
+        View? defaultAcceptView = SuperView?.InternalSubViews.FirstOrDefault (v => v is IDefaultAcceptView defaultAccept && defaultAccept.GetIsDefaultAcceptView ());
+
+        if (defaultAcceptView != this)
+        {
+            bool? handled = defaultAcceptView?.InvokeCommand (Command.Accept, commandContext);
+
+            if (handled == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    protected override bool OnDefaultAcceptView (CommandEventArgs args)
+    {
+        bool? handled = InvokeCommand (Command.Accept, args.Context);
 
         if (handled == true)
         {
             return true;
         }
 
-        SetFocus ();
-
-        // TODO: If `IsDefaultAcceptView` were a property on `View` *any* View could work this way. That's theoretical as
-        // TODO: no use-case has been identified for any View other than Button to act like this.
-        // If Accept was not handled...
-        if (cachedIsDefault && SuperView is { })
-        {
-            return SuperView.InvokeCommand (Command.Accept);
-        }
-
-        return false;
+        return base.OnDefaultAcceptView (args);
     }
+
+    /// <inheritdoc />
+    protected override bool OnHandlingHotKey (CommandEventArgs args)
+    {
+        HandleAcceptCommand (args.Context);
+
+        return base.OnHandlingHotKey (args);
+    }
+
     private void Button_MouseClick (object sender, MouseEventArgs e)
     {
         if (e.Handled)
@@ -145,7 +186,6 @@ public class Button : View, IDesignable, IDefaultAcceptView
         get => GetIsDefaultAcceptView ();
         set => SetIsDefaultAcceptView (value);
     }
-
 
     /// <inheritdoc />
     public bool GetIsDefaultAcceptView () { return _isDefaultAcceptView; }

--- a/Terminal.Gui/Views/MessageBox.cs
+++ b/Terminal.Gui/Views/MessageBox.cs
@@ -359,25 +359,22 @@ public static class MessageBox
                 if (count == defaultButton)
                 {
                     b.IsDefaultAcceptView = true;
-                    b.Accepting += (_, e) =>
-                                   {
-                                       if (e?.Context?.Source is Button button)
-                                       {
-                                           Clicked = (int)button.Data!;
-                                       }
-                                       else
-                                       {
-                                           Clicked = defaultButton;
-                                       }
-
-                                       if (e is { })
-                                       {
-                                           e.Handled = true;
-                                       }
-
-                                       Application.RequestStop ();
-                                   };
                 }
+
+                b.Accepting += (_, e) =>
+                               {
+                                   if (e?.Context?.Source is Button button)
+                                   {
+                                       Clicked = (int)button.Data!;
+                                   }
+                                   else
+                                   {
+                                       Clicked = defaultButton;
+                                   }
+
+
+                                   Application.RequestStop ();
+                               };
 
                 buttonList.Add (b);
                 count++;

--- a/Tests/UnitTests/Application/MainLoopTests.cs
+++ b/Tests/UnitTests/Application/MainLoopTests.cs
@@ -647,7 +647,7 @@ public class MainLoopTests
                                      {
                                          Assert.Null (btn);
                                          Assert.Equal (zero, total);
-                                         Assert.False (btnLaunch.NewKeyDownEvent (Key.Space));
+                                         Assert.True (btnLaunch.NewKeyDownEvent (Key.Space));
 
                                          if (btn == null)
                                          {
@@ -664,7 +664,7 @@ public class MainLoopTests
                                      {
                                          Assert.Equal (clickMe, btn.Text);
                                          Assert.Equal (zero, total);
-                                         Assert.False (btn.NewKeyDownEvent (Key.Space));
+                                         Assert.True (btn.NewKeyDownEvent (Key.Space));
                                          Assert.Equal (cancel, btn.Text);
                                          Assert.Equal (one, total);
                                      }

--- a/Tests/UnitTests/Dialogs/DialogTests.cs
+++ b/Tests/UnitTests/Dialogs/DialogTests.cs
@@ -1113,7 +1113,7 @@ public class DialogTests (ITestOutputHelper output)
                                  break;
 
                              case 1:
-                                 Assert.False (btn1.NewKeyDownEvent (Key.Space));
+                                 Assert.True (btn1.NewKeyDownEvent (Key.Space));
 
                                  break;
                              case 2:
@@ -1130,7 +1130,7 @@ public class DialogTests (ITestOutputHelper output)
   └───────────────────────┘";
                                  DriverAssert.AssertDriverContentsWithFrameAre (expected, output);
 
-                                 Assert.False (btn2!.NewKeyDownEvent (Key.Space));
+                                 Assert.True (btn2!.NewKeyDownEvent (Key.Space));
 
                                  break;
                              case 3:
@@ -1149,7 +1149,7 @@ public class DialogTests (ITestOutputHelper output)
                                                                                 output
                                                                                );
 
-                                 Assert.False (Top!.NewKeyDownEvent (Key.Enter));
+                                 Assert.True (Top!.NewKeyDownEvent (Key.Enter));
 
                                  break;
                              case 4:
@@ -1157,7 +1157,7 @@ public class DialogTests (ITestOutputHelper output)
 
                                  DriverAssert.AssertDriverContentsWithFrameAre (expected, output);
 
-                                 Assert.False (btn3!.NewKeyDownEvent (Key.Space));
+                                 Assert.True (btn3!.NewKeyDownEvent (Key.Space));
 
                                  break;
                              case 5:

--- a/Tests/UnitTests/Dialogs/MessageBoxTests.cs
+++ b/Tests/UnitTests/Dialogs/MessageBoxTests.cs
@@ -33,15 +33,15 @@ public class MessageBoxTests
                                              break;
 
                                          case 2:
-                                             // Tab to btn2
-                                             Application.RaiseKeyDownEvent (Key.Tab);
+                                             // Tab to btn1
+                                             Assert.True (Application.RaiseKeyDownEvent (Key.Tab));
 
                                              var btn = Application.Navigation!.GetFocused () as Button;
 
                                              btn.Accepting += (sender, e) => { btnAcceptCount++; };
 
                                              // Click
-                                             Application.RaiseKeyDownEvent (Key.Enter);
+                                             Assert.True (Application.RaiseKeyDownEvent (Key.Enter));
 
                                              break;
 

--- a/Tests/UnitTests/View/ViewCommandTests.cs
+++ b/Tests/UnitTests/View/ViewCommandTests.cs
@@ -44,8 +44,8 @@ public class ViewCommandTests
         superView.Add (btnOk, btnCancel);
 
         btnCancel.InvokeCommand (Command.Accept);
-        // It's an invocation to the btnCancel which should accept because doesn't make sense both events being raised
-        Assert.Equal (0, acceptOk);
+        // SuperView CanFocus is false, so the command is propagated to the btnOk
+        Assert.Equal (1, acceptOk);
         Assert.Equal (1, acceptCancel);
     }
 

--- a/Tests/UnitTests/View/ViewCommandTests.cs
+++ b/Tests/UnitTests/View/ViewCommandTests.cs
@@ -44,7 +44,8 @@ public class ViewCommandTests
         superView.Add (btnOk, btnCancel);
 
         btnCancel.InvokeCommand (Command.Accept);
-        Assert.Equal (1, acceptOk);
+        // It's an invocation to the btnCancel which should accept because doesn't make sense both events being raised
+        Assert.Equal (0, acceptOk);
         Assert.Equal (1, acceptCancel);
     }
 
@@ -94,7 +95,7 @@ public class ViewCommandTests
 
     [Fact]
     [AutoInitShutdown]
-    public void HotKey_From_Non_IsDefaultAcceptView_Button_Raises_Accept_In_The_Default_Button ()
+    public void HotKey_From_Non_IsDefaultAcceptView_Button_Does_Not_Raises_Accept_In_The_Default_Button ()
     {
         var acceptOk = 0;
         var acceptCancel = 0;
@@ -107,7 +108,8 @@ public class ViewCommandTests
         var rs = Application.Begin (Application.Top);
 
         Application.RaiseKeyDownEvent(Key.C);
-        Assert.Equal (1, acceptOk);
+        // The hotkey is an invocation to the btnCancel which should accept because doesn't make sense both events being raised
+        Assert.Equal (0, acceptOk);
         Assert.Equal (1, acceptCancel);
 
         Application.End (rs);
@@ -173,8 +175,9 @@ public class ViewCommandTests
                                          Flags = MouseFlags.Button1Clicked
                                      });
 
-        // Button A should have been accepted because B didn't cancel and A IsDefaultAcceptView
-        Assert.Equal (1, aAcceptedCount);
+        // Button A should NOT have been accepted because B didn't cancel, although A IsDefaultAcceptView
+        // With mouse click only the button under the mouse should be accepted
+        Assert.Equal (0, aAcceptedCount);
         Assert.Equal (1, bAcceptedCount);
 
         bCancelAccepting = true;
@@ -187,7 +190,8 @@ public class ViewCommandTests
                                      });
 
         // Button A (IsDefaultAcceptView) should NOT have been accepted because B canceled
-        Assert.Equal (1, aAcceptedCount);
+        // With mouse click only the button under the mouse should be accepted
+        Assert.Equal (0, aAcceptedCount);
         Assert.Equal (2, bAcceptedCount);
 
         Application.ResetState (true);

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -737,12 +737,14 @@ public class ButtonTests (ITestOutputHelper output)
         Application.Top = new ();
         Application.Top.Add (btnOk, btnCancel);
         var rs = Application.Begin (Application.Top);
+        Application.Top.Running = true;
         Assert.True (btnOk.HasFocus);
 
         Assert.True (Application.RaiseKeyDownEvent (Key.C));
         Assert.Equal (0, acceptOk);
         Assert.Equal (1, acceptCancel);
         Assert.True (btnCancel.HasFocus);
+        Assert.False (Application.Top.Running);
 
         Application.End (rs);
         Application.Top.Dispose ();
@@ -787,6 +789,7 @@ public class ButtonTests (ITestOutputHelper output)
         Application.Top = new ();
         Application.Top.Add (btnOk, btnCancel);
         var rs = Application.Begin (Application.Top);
+        Application.Top.Running = true;
         Assert.True (btnOk.HasFocus);
 
         Assert.True (Application.RaiseKeyDownEvent (Key.Esc));

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -802,4 +802,54 @@ public class ButtonTests (ITestOutputHelper output)
         Application.Top.Dispose ();
         Application.ResetState ();
     }
+
+    [AutoInitShutdown]
+    [Theory]
+    [InlineData (true, 1, 1, 0)]
+    [InlineData (false, 1, 0, 2)]
+    public void Button_Accepting_Prevents_Further_Processing_No_Mater_IsDefaultView_Is_True_Or_False (
+        bool isDefaultAcceptView,
+        int expectedViewAcceptingCount,
+        int expectedButtonAcceptingCount,
+        int expectedTopAcceptingCount
+    )
+    {
+        var acceptViewInvoked = 0;
+        var acceptButtonInvoked = 0;
+        var acceptTopInvoked = 0;
+        var view = new View { CanFocus = true, Width = 5, Height = 1 };
+        view.Accepting += (_, _) => acceptViewInvoked++;
+        var btn = new Button { Text = "_Test", IsDefaultAcceptView = isDefaultAcceptView };
+        btn.Accepting += (_, _) => acceptButtonInvoked++;
+        Application.Top = new ();
+        Application.Top.Accepting += (_, _) => acceptTopInvoked++;
+        Application.Top.Add (view, btn);
+        view.SetFocus ();
+        Assert.True (view.HasFocus);
+        var downEvent = Application.RaiseKeyDownEvent (Key.Enter);
+        Assert.True (downEvent == isDefaultAcceptView);
+        Assert.Equal (expectedViewAcceptingCount, acceptViewInvoked);
+        Assert.Equal (expectedButtonAcceptingCount, acceptButtonInvoked);
+        Assert.Equal (expectedTopAcceptingCount, acceptTopInvoked);
+        Application.Top.Dispose ();
+    }
+
+    [AutoInitShutdown]
+    [Fact]
+    public void Application_Top_Without_Button_Accepts ()
+    {
+        var acceptViewInvoked = 0;
+        var acceptTopInvoked = 0;
+        var view = new View { CanFocus = true, Width = 5, Height = 1 };
+        view.Accepting += (_, _) => acceptViewInvoked++;
+        Application.Top = new ();
+        Application.Top.Accepting += (_, _) => acceptTopInvoked++;
+        Application.Top.Add (view);
+        view.SetFocus ();
+        Assert.True (view.HasFocus);
+        Assert.False (Application.RaiseKeyDownEvent (Key.Enter));
+        Assert.Equal (1, acceptViewInvoked);
+        Assert.Equal (2, acceptTopInvoked);
+        Application.Top.Dispose ();
+    }
 }

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -252,16 +252,16 @@ public class ButtonTests (ITestOutputHelper output)
         btn.Accepting += (s, e) => clicked = true;
 
         Assert.Equal (KeyCode.T, btn.HotKey);
-        Assert.False (btn.NewKeyDownEvent (Key.T)); // Button processes, but does not handle
+        Assert.True (btn.NewKeyDownEvent (Key.T)); // Button processes and handle
         Assert.True (clicked);
 
         clicked = false;
-        Assert.False (btn.NewKeyDownEvent (Key.T.WithAlt)); // Button processes, but does not handle
+        Assert.True (btn.NewKeyDownEvent (Key.T.WithAlt)); // Button processes and handle
         Assert.True (clicked);
 
         clicked = false;
         btn.HotKey = KeyCode.E;
-        Assert.False (btn.NewKeyDownEvent (Key.E.WithAlt)); // Button processes, but does not handle
+        Assert.True (btn.NewKeyDownEvent (Key.E.WithAlt)); // Button processes and handle
         Assert.True (clicked);
     }
 
@@ -421,56 +421,56 @@ public class ButtonTests (ITestOutputHelper output)
 
         // Hot key. Both alone and with alt
         Assert.Equal (KeyCode.T, btn.HotKey);
-        Assert.False (btn.NewKeyDownEvent (Key.T)); // Button processes, but does not handle
+        Assert.True (btn.NewKeyDownEvent (Key.T)); // Button processes and handle
         Assert.True (clicked);
         clicked = false;
 
-        Assert.False (btn.NewKeyDownEvent (Key.T.WithAlt));
+        Assert.True (btn.NewKeyDownEvent (Key.T.WithAlt));
         Assert.True (clicked);
         clicked = false;
 
-        Assert.False (btn.NewKeyDownEvent (btn.HotKey));
+        Assert.True (btn.NewKeyDownEvent (btn.HotKey));
         Assert.True (clicked);
         clicked = false;
-        Assert.False (btn.NewKeyDownEvent (btn.HotKey));
+        Assert.True (btn.NewKeyDownEvent (btn.HotKey));
         Assert.True (clicked);
         clicked = false;
 
         // IsDefaultAcceptView = false
         // Space and Enter should work
         Assert.False (btn.IsDefaultAcceptView);
-        Assert.False (btn.NewKeyDownEvent (Key.Enter));
+        Assert.True (btn.NewKeyDownEvent (Key.Enter));
         Assert.True (clicked);
         clicked = false;
 
         // IsDefaultAcceptView = true
         // Space and Enter should work
         btn.IsDefaultAcceptView = true;
-        Assert.False (btn.NewKeyDownEvent (Key.Enter));
+        Assert.True (btn.NewKeyDownEvent (Key.Enter));
         Assert.True (clicked);
         clicked = false;
 
         // Toplevel does not handle Enter, so it should get passed on to button
-        Assert.False (Application.Top.NewKeyDownEvent (Key.Enter));
+        Assert.True (Application.Top.NewKeyDownEvent (Key.Enter));
         Assert.True (clicked);
         clicked = false;
 
         // Direct
-        Assert.False (btn.NewKeyDownEvent (Key.Enter));
+        Assert.True (btn.NewKeyDownEvent (Key.Enter));
         Assert.True (clicked);
         clicked = false;
 
-        Assert.False (btn.NewKeyDownEvent (Key.Space));
+        Assert.True (btn.NewKeyDownEvent (Key.Space));
         Assert.True (clicked);
         clicked = false;
 
-        Assert.False (btn.NewKeyDownEvent (new ((KeyCode)'T')));
+        Assert.True (btn.NewKeyDownEvent (new ((KeyCode)'T')));
         Assert.True (clicked);
         clicked = false;
 
         // Change hotkey:
         btn.Text = "Te_st";
-        Assert.False (btn.NewKeyDownEvent (btn.HotKey));
+        Assert.True (btn.NewKeyDownEvent (btn.HotKey));
         Assert.True (clicked);
         clicked = false;
 
@@ -693,5 +693,113 @@ public class ButtonTests (ITestOutputHelper output)
         Assert.Equal (0, activatingCount);
 
         button.Dispose ();
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void MouseClick_From_Non_Default_Button_Does_Not_Raise_Accept_In_The_Default_Button ()
+    {
+        var acceptOk = 0;
+        var acceptCancel = 0;
+        Button btnOk = new () { Id = "Ok", Text = "_Ok", IsDefaultAcceptView = true };
+        btnOk.Accepting += (s, e) => acceptOk++;
+        Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "_Cancel" };
+        btnCancel.Accepting += (s, e) => acceptCancel++;
+        Application.Top = new ();
+        Application.Top.Add (btnOk, btnCancel);
+        var rs = Application.Begin (Application.Top);
+        Assert.True (btnOk.HasFocus);
+
+        Application.RaiseMouseEvent (new () { ScreenPosition = new (0, 1), Flags = MouseFlags.Button1Clicked });
+        Assert.Equal (0, acceptOk);
+        Assert.Equal (1, acceptCancel);
+        Assert.True (btnCancel.HasFocus);
+
+        Application.End (rs);
+        Application.Top.Dispose ();
+        Application.ResetState ();
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void HotKey_From_Non_Default_Button_Does_Not_Raise_Accept_In_The_Default_Button ()
+    {
+        var acceptOk = 0;
+        var acceptCancel = 0;
+        Button btnOk = new () { Id = "Ok", Text = "_Ok", IsDefaultAcceptView = true };
+        btnOk.Accepting += (s, e) => acceptOk++;
+        Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "_Cancel" };
+        btnCancel.Accepting += (s, e) =>
+                               {
+                                   acceptCancel++;
+                                   Application.RequestStop ();
+                               };
+        Application.Top = new ();
+        Application.Top.Add (btnOk, btnCancel);
+        var rs = Application.Begin (Application.Top);
+        Assert.True (btnOk.HasFocus);
+
+        Assert.True (Application.RaiseKeyDownEvent (Key.C));
+        Assert.Equal (0, acceptOk);
+        Assert.Equal (1, acceptCancel);
+        Assert.True (btnCancel.HasFocus);
+
+        Application.End (rs);
+        Application.Top.Dispose ();
+        Application.ResetState ();
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void HotKey_From_Non_Default_Button_Raise_Accept_On_Focused ()
+    {
+        var acceptOk = 0;
+        var acceptCancel = 0;
+        Button btnOk = new () { Id = "Ok", Text = "_Ok" };
+        btnOk.Accepting += (s, e) => acceptOk++;
+        Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "_Cancel" };
+        btnCancel.Accepting += (s, e) => acceptCancel++;
+        Application.Top = new ();
+        Application.Top.Add (btnOk, btnCancel);
+        var rs = Application.Begin (Application.Top);
+        Assert.True (btnOk.HasFocus);
+
+        Assert.True (Application.RaiseKeyDownEvent (Key.Enter));
+        Assert.Equal (1, acceptOk);
+        Assert.Equal (0, acceptCancel);
+        Assert.True (btnOk.HasFocus);
+
+        Application.End (rs);
+        Application.Top.Dispose ();
+        Application.ResetState ();
+    }
+
+    [Fact]
+    [AutoInitShutdown]
+    public void QuitKey_From_Non_Default_Button_Raise_Accept_On_Focused ()
+    {
+        var acceptOk = 0;
+        var acceptCancel = 0;
+        Button btnOk = new () { Id = "Ok", Text = "_Ok" };
+        btnOk.Accepting += (s, e) => acceptOk++;
+        Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "_Cancel", IsDefaultAcceptView = true };
+        btnCancel.Accepting += (s, e) =>
+                               {
+                                   acceptCancel++;
+                                   Application.RequestStop ();
+                               };
+        Application.Top = new ();
+        Application.Top.Add (btnOk, btnCancel);
+        var rs = Application.Begin (Application.Top);
+        Assert.True (btnOk.HasFocus);
+
+        Assert.True (Application.RaiseKeyDownEvent (Key.Esc));
+        Assert.Equal (0, acceptOk);
+        Assert.Equal (1, acceptCancel);
+        Assert.True (btnCancel.HasFocus);
+
+        Application.End (rs);
+        Application.Top.Dispose ();
+        Application.ResetState ();
     }
 }

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -836,6 +836,39 @@ public class ButtonTests (ITestOutputHelper output)
 
     [AutoInitShutdown]
     [Fact]
+    public void Button_IsDefaultView_True_On_Another_SuperView_Accepts_Immediately_If_Event_Was_Not_Handled ()
+    {
+        var acceptViewInvoked = 0;
+        var acceptSuperViewInvoked = 0;
+        var acceptSuperSuperViewInvoked = 0;
+        var acceptButtonInvoked = 0;
+        var acceptTopInvoked = 0;
+        var view = new View { CanFocus = true, Width = 5, Height = 1 };
+        view.Accepting += (_, _) => acceptViewInvoked++;
+        var superView = new View { CanFocus = true, Width = 5, Height = 1 };
+        superView.Accepting += (_, _) => acceptSuperViewInvoked++;
+        superView.Add (view);
+        var superSuperView = new View { CanFocus = true, Width = 5, Height = 1 };
+        superSuperView.Accepting += (_, _) => acceptSuperSuperViewInvoked++;
+        superSuperView.Add (superView);
+        var btnOk = new Button { Text = "_Ok", IsDefaultAcceptView = true };
+        btnOk.Accepting += (_, _) => acceptButtonInvoked++;
+        Application.Top = new ();
+        Application.Top.Accepting += (_, _) => acceptTopInvoked++;
+        Application.Top.Add (superSuperView, btnOk);
+        view.SetFocus ();
+        Assert.True (view.HasFocus);
+        Assert.True (Application.RaiseKeyDownEvent (Key.Enter));
+        Assert.Equal (1, acceptViewInvoked);
+        Assert.Equal (0, acceptSuperViewInvoked);
+        Assert.Equal (0, acceptSuperSuperViewInvoked);
+        Assert.Equal (1, acceptButtonInvoked);
+        Assert.Equal (0, acceptTopInvoked);
+        Application.Top.Dispose ();
+    }
+
+    [AutoInitShutdown]
+    [Fact]
     public void Application_Top_Without_Button_Accepts ()
     {
         var acceptViewInvoked = 0;

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -776,33 +776,6 @@ public class ButtonTests (ITestOutputHelper output)
         Application.ResetState ();
     }
 
-    [Fact]
-    [AutoInitShutdown]
-    public void QuitKey_From_Non_Default_Button_Raise_Accept_On_Focused ()
-    {
-        var acceptOk = 0;
-        var acceptCancel = 0;
-        Button btnOk = new () { Id = "Ok", Text = "_Ok" };
-        btnOk.Accepting += (s, e) => acceptOk++;
-        Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "_Cancel", IsDefaultAcceptView = true };
-        btnCancel.Accepting += (s, e) => acceptCancel++;
-        Application.Top = new ();
-        Application.Top.Add (btnOk, btnCancel);
-        var rs = Application.Begin (Application.Top);
-        Application.Top.Running = true;
-        Assert.True (btnOk.HasFocus);
-
-        Assert.True (Application.RaiseKeyDownEvent (Key.Esc));
-        Assert.Equal (0, acceptOk);
-        Assert.Equal (1, acceptCancel);
-        Assert.True (btnCancel.HasFocus);
-        Assert.False (Application.Top.Running);
-
-        Application.End (rs);
-        Application.Top.Dispose ();
-        Application.ResetState ();
-    }
-
     [AutoInitShutdown]
     [Theory]
     [InlineData (true, 1, 1, 0)]
@@ -884,5 +857,182 @@ public class ButtonTests (ITestOutputHelper output)
         Assert.Equal (1, acceptViewInvoked);
         Assert.Equal (2, acceptTopInvoked);
         Application.Top.Dispose ();
+    }
+
+    [Fact]
+    public void Set_IsDefaultAcceptView_To_True_Set_IsDefaultAccept_To_True_By_Default ()
+    {
+        var button = new Button { IsDefaultAcceptView = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.True (button.IsDefaultAccept);
+        Assert.False (button.IsDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_IsDefaultAcceptView_To_False_Set_IsDefaultAccept_To_False_And_IsDefaultCancel_To_False ()
+    {
+        var button = new Button { IsDefaultAcceptView = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.True (button.IsDefaultAccept);
+        Assert.False (button.IsDefaultCancel);
+
+        button.IsDefaultAcceptView = false;
+        Assert.False (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.False (button.IsDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_IsDefaultAccept_To_True_Set_IsDefaultAcceptView_To_True ()
+    {
+        var button = new Button { IsDefaultAccept = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.True (button.IsDefaultAccept);
+    }
+
+    [Fact]
+    public void Set_IsDefaultAccept_To_False_And_IsDefaultAcceptView_True_Set_IsDefaultCancel_To_True ()
+    {
+        var button = new Button { IsDefaultAcceptView = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.True (button.IsDefaultAccept);
+        Assert.False (button.IsDefaultCancel);
+
+        button.IsDefaultAccept = false;
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_IsDefaultAccept_To_True_And_IsDefaultAcceptView_True_Set_IsDefaultCancel_To_False ()
+    {
+        var button = new Button { IsDefaultAcceptView = true, IsDefaultCancel = true};
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+
+        button.IsDefaultAccept = true;
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.True (button.IsDefaultAccept);
+        Assert.False (button.IsDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_IsDefaultAccept_To_True_And_QuitOnDefaultCancel_True_Set_QuitOnDefaultCancel_To_False ()
+    {
+        var button = new Button { IsDefaultAcceptView = true, QuitOnDefaultCancel = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+        Assert.True (button.QuitOnDefaultCancel);
+
+        button.IsDefaultAccept = true;
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.True (button.IsDefaultAccept);
+        Assert.False (button.IsDefaultCancel);
+        Assert.False (button.QuitOnDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_IsDefaultCancel_To_True_Set_IsDefaultAcceptView_To_True_And_QuitOnDefaultCancel_To_True ()
+    {
+        var button = new Button { IsDefaultCancel = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+        Assert.True (button.QuitOnDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_IsDefaultCancel_To_False_Set_IsDefaultAccept_To_True_And_QuitOnDefaultCancel_To_False ()
+    {
+        var button = new Button { IsDefaultCancel = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+        Assert.True (button.QuitOnDefaultCancel);
+
+        button.IsDefaultCancel = false;
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.True (button.IsDefaultAccept);
+        Assert.False (button.IsDefaultCancel);
+        Assert.False (button.QuitOnDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_QuitOnDefaultCancel_To_True_Set_IsDefaultAcceptView_To_True_And_IsDefaultCancel_To_True ()
+    {
+        var button = new Button { QuitOnDefaultCancel = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+        Assert.True (button.QuitOnDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_QuitOnDefaultCancel_To_True_Set_IsDefaultAccept_To_False_And_IsDefaultCancel_To_True ()
+    {
+        var button = new Button { IsDefaultAcceptView = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.True (button.IsDefaultAccept);
+        Assert.False (button.IsDefaultCancel);
+        Assert.False (button.QuitOnDefaultCancel);
+
+        button.QuitOnDefaultCancel = true;
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+        Assert.True (button.QuitOnDefaultCancel);
+    }
+
+    [Fact]
+    public void Set_QuitOnDefaultCancel_To_False_Keep_IsDefaultAccept_To_False ()
+    {
+        var button = new Button { IsDefaultAcceptView = true, IsDefaultCancel = true };
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+        Assert.True (button.QuitOnDefaultCancel);
+
+        button.QuitOnDefaultCancel = false;
+        Assert.True (button.IsDefaultAcceptView);
+        Assert.False (button.IsDefaultAccept);
+        Assert.True (button.IsDefaultCancel);
+        Assert.False (button.QuitOnDefaultCancel);
+    }
+
+    [Theory]
+    [InlineData (true)]
+    [InlineData (false)]
+    [AutoInitShutdown]
+    public void QuitKey_From_Non_Default_Button_Raise_Accept_On_Focused (bool quitOnDefaultCancel)
+    {
+        var acceptOk = 0;
+        var acceptCancel = 0;
+        Button btnOk = new () { Id = "Ok", Text = "_Ok" };
+        btnOk.Accepting += (s, e) => acceptOk++;
+
+        Button btnCancel = new ()
+        {
+            Id = "Cancel", Y = 1, Text = "_Cancel",
+            IsDefaultAcceptView = true, IsDefaultCancel = true, QuitOnDefaultCancel = quitOnDefaultCancel
+        };
+        btnCancel.Accepting += (s, e) => acceptCancel++;
+        Application.Top = new ();
+        Application.Top.Add (btnOk, btnCancel);
+        var rs = Application.Begin (Application.Top);
+        Application.Top.Running = true;
+        Assert.True (btnOk.HasFocus);
+
+        Assert.True (Application.RaiseKeyDownEvent (Key.Esc));
+        Assert.Equal (0, acceptOk);
+        Assert.Equal (1, acceptCancel);
+        Assert.True (btnCancel.HasFocus);
+        Assert.True (Application.Top.Running == !quitOnDefaultCancel);
+
+        Application.End (rs);
+        Application.Top.Dispose ();
+        Application.ResetState ();
     }
 }

--- a/Tests/UnitTests/Views/ButtonTests.cs
+++ b/Tests/UnitTests/Views/ButtonTests.cs
@@ -783,11 +783,7 @@ public class ButtonTests (ITestOutputHelper output)
         Button btnOk = new () { Id = "Ok", Text = "_Ok" };
         btnOk.Accepting += (s, e) => acceptOk++;
         Button btnCancel = new () { Id = "Cancel", Y = 1, Text = "_Cancel", IsDefaultAcceptView = true };
-        btnCancel.Accepting += (s, e) =>
-                               {
-                                   acceptCancel++;
-                                   Application.RequestStop ();
-                               };
+        btnCancel.Accepting += (s, e) => acceptCancel++;
         Application.Top = new ();
         Application.Top.Add (btnOk, btnCancel);
         var rs = Application.Begin (Application.Top);
@@ -797,6 +793,7 @@ public class ButtonTests (ITestOutputHelper output)
         Assert.Equal (0, acceptOk);
         Assert.Equal (1, acceptCancel);
         Assert.True (btnCancel.HasFocus);
+        Assert.False (Application.Top.Running);
 
         Application.End (rs);
         Application.Top.Dispose ();

--- a/Tests/UnitTestsParallelizable/View/ViewCommandTests.cs
+++ b/Tests/UnitTestsParallelizable/View/ViewCommandTests.cs
@@ -19,7 +19,7 @@ public class ViewCommandTests
     }
 
     [Fact]
-    public void Accept_Command_Handle_OnAccept_NoEvent ()
+    public void Accept_Command_Handle_OnAccept_With_Event_Not_Handled ()
     {
         var view = new ViewEventTester ();
         Assert.False (view.HasFocus);
@@ -29,7 +29,7 @@ public class ViewCommandTests
 
         Assert.Equal (1, view.OnAcceptedCount);
 
-        Assert.Equal (0, view.AcceptedCount);
+        Assert.Equal (1, view.AcceptedCount);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class ViewCommandTests
         subview.HandleOnAccepted = false;
         subview.HandleAccepted = true;
         subview.InvokeCommand (Command.Accept);
-        Assert.Equal (3, subview.OnAcceptedCount);
+        Assert.Equal (2, subview.OnAcceptedCount);
         Assert.Equal (1, view.OnAcceptedCount);
 
         // Add a super view to test deeper hierarchy
@@ -97,20 +97,20 @@ public class ViewCommandTests
         superView.Add (view);
 
         subview.InvokeCommand (Command.Accept);
-        Assert.Equal (4, subview.OnAcceptedCount);
+        Assert.Equal (2, subview.OnAcceptedCount);
         Assert.Equal (1, view.OnAcceptedCount);
         Assert.Equal (0, superView.OnAcceptedCount);
 
         subview.HandleAccepted = false;
         subview.InvokeCommand (Command.Accept);
-        Assert.Equal (5, subview.OnAcceptedCount);
+        Assert.Equal (3, subview.OnAcceptedCount);
         Assert.Equal (2, view.OnAcceptedCount);
         Assert.Equal (1, superView.OnAcceptedCount);
 
         view.HandleAccepted = true;
         subview.InvokeCommand (Command.Accept);
-        Assert.Equal (6, subview.OnAcceptedCount);
-        Assert.Equal (3, view.OnAcceptedCount);
+        Assert.Equal (4, subview.OnAcceptedCount);
+        Assert.Equal (2, view.OnAcceptedCount);
         Assert.Equal (1, superView.OnAcceptedCount);
     }
 

--- a/Tests/UnitTestsParallelizable/Views/AllViewsTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/AllViewsTests.cs
@@ -104,7 +104,15 @@ public class AllViewsTests (ITestOutputHelper output) : TestsAllViews
 
         if (view.InvokeCommand (Command.Accept) == true)
         {
-            Assert.Equal (0, activatingCount);
+            if (view is Button)
+            {
+                // Button is the only view that activate on the accept command
+                Assert.Equal (1, activatingCount);
+            }
+            else
+            {
+                Assert.Equal (0, activatingCount);
+            }
             Assert.Equal (1, acceptingCount);
         }
         view?.Dispose ();
@@ -141,7 +149,16 @@ public class AllViewsTests (ITestOutputHelper output) : TestsAllViews
         if (view.InvokeCommand (Command.HotKey) == true)
         {
             Assert.Equal (1, handlingHotKeyCount);
-            Assert.Equal (0, acceptedCount);
+
+            if (view is Button)
+            {
+                // Button is the only view that accepts on the hotkey command
+                Assert.Equal (1, acceptedCount);
+            }
+            else
+            {
+                Assert.Equal (0, acceptedCount);
+            }
         }
         view?.Dispose ();
     }


### PR DESCRIPTION
## Fixes

- Fixes #4170

## Proposed Changes/Todos

- [x] Please see all the comments in https://github.com/gui-cs/Terminal.Gui/issues/4170#issuecomment-3039019916 and https://github.com/gui-cs/Terminal.Gui/issues/4170#issuecomment-3039084242

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
