### PR TITLE
Command system redesign: Phases A, B, C, E

### DIFF
--- a/Examples/UICatalog/Scenarios/Menus.cs
+++ b/Examples/UICatalog/Scenarios/Menus.cs
@@ -266,8 +266,9 @@ public class Menus : Scenario
 
             // Set up the Context Menu
             ContextMenu = new PopoverMenu { Title = "ContextMenu", Id = "ContextMenu" };
-            ContextMenu?.EnableForDesign (ref host);
-
+            Menu testContextMenu = new () { Id = "TestContextMenu" };
+            ContextMenu.Root = testContextMenu;
+            ConfigureTestMenu (testContextMenu);
             ContextMenu?.Visible = false;
 
             // Demo of PopoverMenu as a context menu

--- a/Examples/UICatalog/Scenarios/Menus.cs
+++ b/Examples/UICatalog/Scenarios/Menus.cs
@@ -266,9 +266,7 @@ public class Menus : Scenario
 
             // Set up the Context Menu
             ContextMenu = new PopoverMenu { Title = "ContextMenu", Id = "ContextMenu" };
-            Menu testContextMenu = new () { Y = Pos.Bottom (editModeStatusCb) + 1, Id = "TestMenu" };
-            ConfigureTestMenu (testContextMenu);
-            ContextMenu?.Root = testContextMenu;
+            ContextMenu?.EnableForDesign (ref host);
 
             ContextMenu?.Visible = false;
 

--- a/Examples/UICatalog/Scenarios/Menus.cs
+++ b/Examples/UICatalog/Scenarios/Menus.cs
@@ -266,7 +266,9 @@ public class Menus : Scenario
 
             // Set up the Context Menu
             ContextMenu = new PopoverMenu { Title = "ContextMenu", Id = "ContextMenu" };
-            ContextMenu?.EnableForDesign (ref host);
+            Menu testContextMenu = new () { Y = Pos.Bottom (editModeStatusCb) + 1, Id = "TestMenu" };
+            ConfigureTestMenu (testContextMenu);
+            ContextMenu?.Root = testContextMenu;
 
             ContextMenu?.Visible = false;
 

--- a/Terminal.Gui/App/Keyboard/KeyboardImpl.cs
+++ b/Terminal.Gui/App/Keyboard/KeyboardImpl.cs
@@ -222,7 +222,7 @@ internal class KeyboardImpl : IKeyboard, IDisposable
                     return null;
                 }
 
-                handled = binding.Target?.InvokeCommands (binding.Commands, binding with { Source = binding.Target });
+                handled = binding.Target?.InvokeCommands (binding.Commands, binding with { Source = binding.Target is { } t ? new WeakReference<View> (t) : null });
             }
             else
             {

--- a/Terminal.Gui/Input/CommandBinding.cs
+++ b/Terminal.Gui/Input/CommandBinding.cs
@@ -11,9 +11,9 @@ namespace Terminal.Gui.Input;
 ///         but is not associated with a specific key or mouse event.
 ///     </para>
 ///     <para>
-///         <see cref="Source"/> is the View that called <see cref="View.InvokeCommand(Command)"/>g. If
-///         <see langword="null"/> the
-///         CommandBinding instance was created dynamically (not from a mouse or keyboard binding).
+///         <see cref="Source"/> is a weak reference to the View that called <see cref="View.InvokeCommand(Command)"/>.
+///         If <see langword="null"/> the CommandBinding instance was created dynamically (not from a mouse or keyboard
+///         binding).
 ///     </para>
 ///     <para>
 ///         Pattern match on binding types to discriminate between input sources:
@@ -36,7 +36,7 @@ public readonly record struct CommandBinding : ICommandBinding
     public CommandBinding (Command [] commands, View? source = null, object? data = null)
     {
         Commands = commands;
-        Source = source;
+        Source = source is { } ? new WeakReference<View> (source) : null;
         Data = data;
     }
 
@@ -47,8 +47,18 @@ public readonly record struct CommandBinding : ICommandBinding
     public object? Data { get; init; }
 
     /// <inheritdoc/>
-    public View? Source { get; init; }
+    public WeakReference<View>? Source { get; init; }
 
     /// <inheritdoc/>
-    public override string ToString () => $"[{string.Join (", ", Commands)}], Source={Source}, Data={Data}";
+    public override string ToString ()
+    {
+        string sourceStr = "null";
+
+        if (Source?.TryGetTarget (out View? sv) == true)
+        {
+            sourceStr = sv.ToIdentifyingString ();
+        }
+
+        return $"[{string.Join (", ", Commands)}], Source={sourceStr}, Data={Data}";
+    }
 }

--- a/Terminal.Gui/Input/CommandBridge.cs
+++ b/Terminal.Gui/Input/CommandBridge.cs
@@ -1,0 +1,115 @@
+namespace Terminal.Gui.Input;
+
+/// <summary>
+///     Bridges command routing across non-containment boundaries (e.g., between a <see cref="MenuBarItem"/>
+///     and its <see cref="PopoverMenu"/>, which is registered with Application.Popover rather than the
+///     SuperView hierarchy).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The bridge subscribes to the remote view's <c>Accepted</c> and/or <c>Activated</c> events.
+///         When fired, it creates a new immutable <see cref="CommandContext"/> with
+///         <see cref="CommandRouting.Bridged"/> routing and invokes the command on the owner via
+///         <see cref="View.InvokeCommand(Command, ICommandContext?)"/>.
+///     </para>
+///     <para>
+///         Both references are weak — the bridge does not prevent GC of either view.
+///         The bridge becomes inert if either <see cref="WeakReference{T}"/> target is collected.
+///     </para>
+///     <para>
+///         The bridge is one-way: remote fires event → owner receives command.
+///         If bidirectional routing is needed, create two bridges.
+///     </para>
+/// </remarks>
+public class CommandBridge : IDisposable
+{
+    private readonly WeakReference<View> _owner;
+    private readonly WeakReference<View> _remote;
+    private readonly Command [] _commands;
+    private bool _disposed;
+
+    private CommandBridge (View owner, View remote, Command [] commands)
+    {
+        _owner = new WeakReference<View> (owner);
+        _remote = new WeakReference<View> (remote);
+        _commands = commands;
+
+        // Subscribe to the remote view's completion events for bridged commands.
+        if (_commands.Contains (Command.Accept))
+        {
+            remote.Accepted += OnRemoteAccepted;
+        }
+
+        if (_commands.Contains (Command.Activate))
+        {
+            remote.Activated += OnRemoteActivated;
+        }
+    }
+
+    /// <summary>
+    ///     Connects an owner view to a remote view for the specified commands.
+    ///     When the remote view raises <c>Accepted</c> or <c>Activated</c> for any of the
+    ///     specified commands, the owner view receives the command with
+    ///     <see cref="CommandRouting.Bridged"/> routing.
+    /// </summary>
+    /// <param name="owner">The view that will receive bridged commands.</param>
+    /// <param name="remote">The view whose events will be bridged.</param>
+    /// <param name="commands">The commands to bridge (e.g., <c>Command.Accept</c>, <c>Command.Activate</c>).</param>
+    /// <returns>A <see cref="CommandBridge"/> that can be disposed to tear down the connection.</returns>
+    public static CommandBridge Connect (View owner, View remote, params Command [] commands) => new (owner, remote, commands);
+
+    /// <summary>
+    ///     Tears down event subscriptions. Safe to call multiple times.
+    /// </summary>
+    public void Dispose ()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        if (_remote.TryGetTarget (out View? remote))
+        {
+            remote.Accepted -= OnRemoteAccepted;
+            remote.Activated -= OnRemoteActivated;
+        }
+    }
+
+    private void OnRemoteAccepted (object? sender, CommandEventArgs e)
+    {
+        if (_disposed || !_owner.TryGetTarget (out View? owner))
+        {
+            return;
+        }
+
+        CommandContext bridgedCtx = new ()
+        {
+            Command = Command.Accept,
+            Source = e.Context?.Source,
+            Binding = e.Context?.Binding,
+            Routing = CommandRouting.Bridged
+        };
+
+        owner.RaiseAccepted (bridgedCtx);
+    }
+
+    private void OnRemoteActivated (object? sender, EventArgs<ICommandContext?> e)
+    {
+        if (_disposed || !_owner.TryGetTarget (out View? owner))
+        {
+            return;
+        }
+
+        CommandContext bridgedCtx = new ()
+        {
+            Command = Command.Activate,
+            Source = e.Value?.Source,
+            Binding = e.Value?.Binding,
+            Routing = CommandRouting.Bridged
+        };
+
+        owner.RaiseActivated (bridgedCtx);
+    }
+}

--- a/Terminal.Gui/Input/CommandContext.cs
+++ b/Terminal.Gui/Input/CommandContext.cs
@@ -48,38 +48,6 @@ public readonly record struct CommandContext : ICommandContext
     /// <inheritdoc/>
     public CommandRouting Routing { get; init; }
 
-    /// <inheritdoc/>
-    /// <remarks>
-    ///     Backward-compatible property. Equivalent to <c>Routing == CommandRouting.DispatchingDown</c>.
-    /// </remarks>
-    public bool IsBubblingDown
-    {
-        get => Routing == CommandRouting.DispatchingDown;
-        init
-        {
-            if (value)
-            {
-                Routing = CommandRouting.DispatchingDown;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    /// <remarks>
-    ///     Backward-compatible property. Equivalent to <c>Routing == CommandRouting.BubblingUp</c>.
-    /// </remarks>
-    public bool IsBubblingUp
-    {
-        get => Routing == CommandRouting.BubblingUp;
-        init
-        {
-            if (value)
-            {
-                Routing = CommandRouting.BubblingUp;
-            }
-        }
-    }
-
     /// <summary>
     ///     Creates a new context with a different command, preserving all other fields.
     /// </summary>
@@ -95,5 +63,5 @@ public readonly record struct CommandContext : ICommandContext
     public CommandContext WithRouting (CommandRouting routing) => this with { Routing = routing };
 
     /// <inheritdoc/>
-    public override string ToString () => $"{(IsBubblingUp ? Glyphs.UpArrow : IsBubblingDown ? Glyphs.DownArrow : "")}{Command} ({(Source is { } ? $"Source={Source.ToIdentifyingString ()}" : "")}{(Binding is { } ? $", Binding={Binding}" : "")})";
+    public override string ToString () => $"{(Routing == CommandRouting.BubblingUp ? Glyphs.UpArrow : Routing == CommandRouting.DispatchingDown ? Glyphs.DownArrow : "")}{Command} ({(Source is { } ? $"Source={Source.ToIdentifyingString ()}" : "")}{(Binding is { } ? $", Binding={Binding}" : "")})";
 }

--- a/Terminal.Gui/Input/CommandContext.cs
+++ b/Terminal.Gui/Input/CommandContext.cs
@@ -1,10 +1,14 @@
-﻿namespace Terminal.Gui.Input;
+namespace Terminal.Gui.Input;
 
 #pragma warning disable CS1574, CS0419 // XML comment has cref attribute that could not be resolved
 /// <summary>
 ///     Provides context for a <see cref="Command"/> invocation.
 /// </summary>
 /// <remarks>
+///     <para>
+///         <see cref="CommandContext"/> is immutable. Use <see cref="WithCommand"/> or <see cref="WithRouting"/>
+///         to create a new context with modified values while preserving all other fields.
+///     </para>
 ///     <para>
 ///         Use pattern matching to access specific binding types:
 ///         <code>
@@ -17,7 +21,7 @@
 /// <seealso cref="View.InvokeCommand"/>
 /// .
 #pragma warning restore CS1574, CS0419 // XML comment has cref attribute that could not be resolved
-public record struct CommandContext : ICommandContext
+public readonly record struct CommandContext : ICommandContext
 {
     /// <summary>
     ///     Initializes a new instance with the specified <see cref="Command"/>.
@@ -33,19 +37,62 @@ public record struct CommandContext : ICommandContext
     }
 
     /// <inheritdoc/>
-    public Command Command { get; set; }
+    public Command Command { get; init; }
 
     /// <inheritdoc/>
-    public WeakReference<View>? Source { get; set; }
+    public WeakReference<View>? Source { get; init; }
 
     /// <inheritdoc/>
-    public ICommandBinding? Binding { get; set; }
+    public ICommandBinding? Binding { get; init; }
 
     /// <inheritdoc/>
-    public bool IsBubblingDown { get; init; }
+    public CommandRouting Routing { get; init; }
 
-    /// <inheritdoc />
-    public bool IsBubblingUp { get; init; }
+    /// <inheritdoc/>
+    /// <remarks>
+    ///     Backward-compatible property. Equivalent to <c>Routing == CommandRouting.DispatchingDown</c>.
+    /// </remarks>
+    public bool IsBubblingDown
+    {
+        get => Routing == CommandRouting.DispatchingDown;
+        init
+        {
+            if (value)
+            {
+                Routing = CommandRouting.DispatchingDown;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    ///     Backward-compatible property. Equivalent to <c>Routing == CommandRouting.BubblingUp</c>.
+    /// </remarks>
+    public bool IsBubblingUp
+    {
+        get => Routing == CommandRouting.BubblingUp;
+        init
+        {
+            if (value)
+            {
+                Routing = CommandRouting.BubblingUp;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Creates a new context with a different command, preserving all other fields.
+    /// </summary>
+    /// <param name="command">The new command.</param>
+    /// <returns>A new <see cref="CommandContext"/> with the specified command.</returns>
+    public CommandContext WithCommand (Command command) => this with { Command = command };
+
+    /// <summary>
+    ///     Creates a new context with different routing, preserving all other fields.
+    /// </summary>
+    /// <param name="routing">The new routing mode.</param>
+    /// <returns>A new <see cref="CommandContext"/> with the specified routing.</returns>
+    public CommandContext WithRouting (CommandRouting routing) => this with { Routing = routing };
 
     /// <inheritdoc/>
     public override string ToString () => $"{(IsBubblingUp ? Glyphs.UpArrow : IsBubblingDown ? Glyphs.DownArrow : "")}{Command} ({(Source is { } ? $"Source={Source.ToIdentifyingString ()}" : "")}{(Binding is { } ? $", Binding={Binding}" : "")})";

--- a/Terminal.Gui/Input/CommandOutcome.cs
+++ b/Terminal.Gui/Input/CommandOutcome.cs
@@ -1,0 +1,61 @@
+namespace Terminal.Gui.Input;
+
+/// <summary>
+///     Describes the outcome of a <see cref="Command"/> invocation, replacing the three-valued <c>bool?</c>
+///     (<see langword="null"/> = not found, <see langword="false"/> = not handled, <see langword="true"/> = handled).
+/// </summary>
+public enum CommandOutcome
+{
+    /// <summary>
+    ///     The command was not handled; routing continues.
+    /// </summary>
+    NotHandled,
+
+    /// <summary>
+    ///     The command was handled; routing stops.
+    /// </summary>
+    HandledStop,
+
+    /// <summary>
+    ///     The command was handled but routing may continue (notification semantics).
+    /// </summary>
+    HandledContinue,
+}
+
+/// <summary>
+///     Provides extension methods for converting between <see cref="CommandOutcome"/> and <c>bool?</c>.
+/// </summary>
+public static class CommandOutcomeExtensions
+{
+    /// <summary>
+    ///     Converts a <see cref="CommandOutcome"/> to a nullable boolean for backward compatibility.
+    /// </summary>
+    /// <param name="outcome">The outcome to convert.</param>
+    /// <returns>
+    ///     <see langword="true"/> for <see cref="CommandOutcome.HandledStop"/>,
+    ///     <see langword="false"/> for <see cref="CommandOutcome.HandledContinue"/>,
+    ///     <see langword="null"/> for <see cref="CommandOutcome.NotHandled"/>.
+    /// </returns>
+    public static bool? ToBool (this CommandOutcome outcome) => outcome switch
+    {
+        CommandOutcome.HandledStop => true,
+        CommandOutcome.HandledContinue => false,
+        _ => null
+    };
+
+    /// <summary>
+    ///     Converts a nullable boolean to a <see cref="CommandOutcome"/>.
+    /// </summary>
+    /// <param name="result">The nullable boolean to convert.</param>
+    /// <returns>
+    ///     <see cref="CommandOutcome.HandledStop"/> for <see langword="true"/>,
+    ///     <see cref="CommandOutcome.HandledContinue"/> for <see langword="false"/>,
+    ///     <see cref="CommandOutcome.NotHandled"/> for <see langword="null"/>.
+    /// </returns>
+    public static CommandOutcome ToOutcome (this bool? result) => result switch
+    {
+        true => CommandOutcome.HandledStop,
+        false => CommandOutcome.HandledContinue,
+        null => CommandOutcome.NotHandled
+    };
+}

--- a/Terminal.Gui/Input/CommandRouting.cs
+++ b/Terminal.Gui/Input/CommandRouting.cs
@@ -1,0 +1,29 @@
+namespace Terminal.Gui.Input;
+
+/// <summary>
+///     Describes how a <see cref="Command"/> is being routed through the view hierarchy.
+///     Replaces the ad-hoc boolean flags <c>IsBubblingUp</c> and <c>IsBubblingDown</c>
+///     with a single discriminated enum.
+/// </summary>
+public enum CommandRouting
+{
+    /// <summary>
+    ///     Direct invocation (programmatic or from this view's own bindings).
+    /// </summary>
+    Direct,
+
+    /// <summary>
+    ///     The command is propagating upward through the SuperView chain.
+    /// </summary>
+    BubblingUp,
+
+    /// <summary>
+    ///     A SuperView is dispatching downward to a specific SubView.
+    /// </summary>
+    DispatchingDown,
+
+    /// <summary>
+    ///     The command is crossing a non-containment boundary via <see cref="CommandBridge"/>.
+    /// </summary>
+    Bridged,
+}

--- a/Terminal.Gui/Input/ICommandBinding.cs
+++ b/Terminal.Gui/Input/ICommandBinding.cs
@@ -1,4 +1,4 @@
-﻿namespace Terminal.Gui.Input;
+namespace Terminal.Gui.Input;
 
 /// <summary>
 ///     Describes command binding. Used to bind a set of <see cref="Command"/> objects to a specific user event and
@@ -18,9 +18,13 @@ public interface ICommandBinding
     public object? Data { get; init; }
 
     /// <summary>
-    ///     Gets or sets the <see cref="View"/> that registered the binding.
+    ///     Gets the <see cref="View"/> that registered the binding as a weak reference.
     /// </summary>
     /// <remarks>
+    ///     <para>
+    ///         Uses <see cref="WeakReference{T}"/> to prevent memory leaks when views are disposed
+    ///         while bindings still reference them.
+    ///     </para>
     ///     <para>
     ///         For key bindings, this is the view that registered the binding.
     ///     </para>
@@ -31,5 +35,5 @@ public interface ICommandBinding
     ///         For programmatic invocations, this is the view that called <see cref="View.InvokeCommand(Command)"/>.
     ///     </para>
     /// </remarks>
-    public View? Source { get; init; }
+    public WeakReference<View>? Source { get; init; }
 }

--- a/Terminal.Gui/Input/ICommandContext.cs
+++ b/Terminal.Gui/Input/ICommandContext.cs
@@ -46,22 +46,4 @@ public interface ICommandContext
     ///     Gets the routing mode for this command invocation.
     /// </summary>
     public CommandRouting Routing { get; }
-
-    /// <summary>
-    ///     Gets whether this command is being dispatched downward to a SubView. When <see langword="true"/>,
-    ///     <see cref="View.TryBubbleUp"/> will skip bubbling, preventing re-entry.
-    /// </summary>
-    /// <remarks>
-    ///     Backward-compatible property. Equivalent to <c>Routing == CommandRouting.DispatchingDown</c>.
-    /// </remarks>
-    public bool IsBubblingDown { get; }
-
-    /// <summary>
-    ///     Gets whether this command is being dispatched upward to a SuperView. When <see langword="true"/>,
-    ///     <see cref="View.BubbleDown"/> will skip bubbling, preventing re-entry.
-    /// </summary>
-    /// <remarks>
-    ///     Backward-compatible property. Equivalent to <c>Routing == CommandRouting.BubblingUp</c>.
-    /// </remarks>
-    public bool IsBubblingUp { get; }
 }

--- a/Terminal.Gui/Input/ICommandContext.cs
+++ b/Terminal.Gui/Input/ICommandContext.cs
@@ -1,4 +1,4 @@
-﻿namespace Terminal.Gui.Input;
+namespace Terminal.Gui.Input;
 
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
 /// <summary>
@@ -14,7 +14,7 @@ public interface ICommandContext
     /// <summary>
     ///     The <see cref="Command"/> that is being invoked.
     /// </summary>
-    public Command Command { get; set; }
+    public Command Command { get; }
 
     /// <summary>
     ///     A weak reference to the View that was the source of the command invocation, if any.
@@ -25,7 +25,7 @@ public interface ICommandContext
     ///     Uses WeakReference to prevent memory leaks and access to disposed views when views are disposed during command
     ///     propagation.
     /// </remarks>
-    public WeakReference<View>? Source { get; set; }
+    public WeakReference<View>? Source { get; }
 
     /// <summary>
     ///     The binding that triggered the command.
@@ -43,15 +43,25 @@ public interface ICommandContext
     public ICommandBinding? Binding { get; }
 
     /// <summary>
+    ///     Gets the routing mode for this command invocation.
+    /// </summary>
+    public CommandRouting Routing { get; }
+
+    /// <summary>
     ///     Gets whether this command is being dispatched downward to a SubView. When <see langword="true"/>,
     ///     <see cref="View.TryBubbleUp"/> will skip bubbling, preventing re-entry.
     /// </summary>
+    /// <remarks>
+    ///     Backward-compatible property. Equivalent to <c>Routing == CommandRouting.DispatchingDown</c>.
+    /// </remarks>
     public bool IsBubblingDown { get; }
 
     /// <summary>
     ///     Gets whether this command is being dispatched upward to a SuperView. When <see langword="true"/>,
     ///     <see cref="View.BubbleDown"/> will skip bubbling, preventing re-entry.
     /// </summary>
+    /// <remarks>
+    ///     Backward-compatible property. Equivalent to <c>Routing == CommandRouting.BubblingUp</c>.
+    /// </remarks>
     public bool IsBubblingUp { get; }
-
 }

--- a/Terminal.Gui/Input/Keyboard/KeyBinding.cs
+++ b/Terminal.Gui/Input/Keyboard/KeyBinding.cs
@@ -44,7 +44,7 @@ public record struct KeyBinding : ICommandBinding
     public KeyBinding (Command [] commands, Key newKey, View? source = null, View? target = null, object? data = null)
     {
         Commands = commands;
-        Source = source;
+        Source = source is { } ? new WeakReference<View> (source) : null;
         Key = newKey;
         Target = target;
         Data = data;
@@ -62,7 +62,7 @@ public record struct KeyBinding : ICommandBinding
     public Key? Key { get; set; }
 
     /// <inheritdoc/>
-    public View? Source { get; init; }
+    public WeakReference<View>? Source { get; init; }
 
     // TODO: Determine if Target is duplicative of Source
     /// <summary>
@@ -80,5 +80,22 @@ public record struct KeyBinding : ICommandBinding
     public View? Target { get; set; }
 
     /// <inheritdoc />
-    public override string ToString () => $"[{string.Join (", ", Commands)}], Key={Key}{(Source is { } ? $", Source={Source.ToIdentifyingString ()}" : "")}{(Target is { } ? $", Source={Target.ToIdentifyingString ()}" : "")}{(Data is { } ? ", Data=" : "")}";
+    public override string ToString ()
+    {
+        string sourceStr = "";
+
+        if (Source?.TryGetTarget (out View? sv) == true)
+        {
+            sourceStr = $", Source={sv.ToIdentifyingString ()}";
+        }
+
+        string targetStr = "";
+
+        if (Target is { })
+        {
+            targetStr = $", Target={Target.ToIdentifyingString ()}";
+        }
+
+        return $"[{string.Join (", ", Commands)}], Key={Key}{sourceStr}{targetStr}{(Data is { } ? ", Data=" : "")}";
+    }
 }

--- a/Terminal.Gui/Input/Mouse/MouseBinding.cs
+++ b/Terminal.Gui/Input/Mouse/MouseBinding.cs
@@ -17,7 +17,7 @@ public record struct MouseBinding : ICommandBinding
     {
         Commands = commands;
         MouseEvent = new Mouse { Timestamp = DateTime.Now, Flags = mouseFlags };
-        Source = source;
+        Source = source is { } ? new WeakReference<View> (source) : null;
     }
 
     /// <summary>Initializes a new instance.</summary>
@@ -36,7 +36,7 @@ public record struct MouseBinding : ICommandBinding
     public object? Data { get; init; }
 
     /// <inheritdoc/>
-    public View? Source { get; init; }
+    public WeakReference<View>? Source { get; init; }
 
     /// <summary>
     ///     The mouse event data associated with this binding.
@@ -44,6 +44,15 @@ public record struct MouseBinding : ICommandBinding
     public Mouse? MouseEvent { get; set; }
 
     /// <inheritdoc/>
-    public override string ToString () =>
-        $"[{string.Join (", ", Commands)}] (MouseEvent={MouseEvent}{(Source is { } ? $", Source={Source.ToIdentifyingString ()}" : "")}{(Data is { } ? ", Data=" : "")}";
+    public override string ToString ()
+    {
+        string sourceStr = "";
+
+        if (Source?.TryGetTarget (out View? sv) == true)
+        {
+            sourceStr = $", Source={sv.ToIdentifyingString ()}";
+        }
+
+        return $"[{string.Join (", ", Commands)}] (MouseEvent={MouseEvent}{sourceStr}{(Data is { } ? ", Data=" : "")})";
+    }
 }

--- a/Terminal.Gui/ViewBase/Mouse/View.Mouse.cs
+++ b/Terminal.Gui/ViewBase/Mouse/View.Mouse.cs
@@ -815,7 +815,7 @@ public partial class View // Mouse APIs
             return null;
         }
 
-        return InvokeCommands (binding.Commands, binding with { MouseEvent = mouseEventArgs, Source = this });
+        return InvokeCommands (binding.Commands, binding with { MouseEvent = mouseEventArgs, Source = new WeakReference<View> (this) });
     }
 
     #endregion Command Invocation

--- a/Terminal.Gui/ViewBase/Mouse/View.Mouse.cs
+++ b/Terminal.Gui/ViewBase/Mouse/View.Mouse.cs
@@ -759,10 +759,12 @@ public partial class View // Mouse APIs
             return args.Handled = false;
         }
 
-        //Logging.Trace ($"Invoking commands bound to mouse: {args.Flags}");
+        Logging.Debug ($"{this.ToIdentifyingString ()} {args}");
+
         // By default, this will raise Activating/OnActivating - Subclasses can override this via
         // ReplaceCommand (Command.Activate ...).
         args.Handled = InvokeCommandsBoundToMouse (args) == true;
+        Logging.Debug ($"{this.ToIdentifyingString ()} handled={args.Handled}");
 
         return args.Handled;
     }

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -812,9 +812,8 @@ public partial class View // Command APIs
         if (!IsSourceWithinView (target, ctx))
         {
             BubbleDown (target, ctx);
+            _lastDispatchOccurred = true;
         }
-
-        _lastDispatchOccurred = true;
 
         return false;
     }

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -398,7 +398,7 @@ public partial class View // Command APIs
     /// </remarks>
     /// <param name="ctx">The command context.</param>
     /// <seealso cref="RaiseAccepting"/>
-    protected void RaiseAccepted (ICommandContext? ctx)
+    internal protected void RaiseAccepted (ICommandContext? ctx)
     {
         OnAccepted (ctx);
         Accepted?.Invoke (this, new CommandEventArgs { Context = ctx });
@@ -580,7 +580,7 @@ public partial class View // Command APIs
     /// </remarks>
     /// <param name="ctx">The command context.</param>
     /// <seealso cref="RaiseActivating"/>
-    protected void RaiseActivated (ICommandContext? ctx)
+    internal protected void RaiseActivated (ICommandContext? ctx)
     {
         // Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
         OnActivated (ctx);

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -279,7 +279,7 @@ public partial class View // Command APIs
         }
 
         // Composite views with dispatch targets always get completion on bubble.
-        if (ctx?.IsBubblingUp == true && GetDispatchTarget (ctx) is { })
+        if (ctx?.Routing == CommandRouting.BubblingUp && GetDispatchTarget (ctx) is { })
         {
             RaiseAccepted (ctx);
 
@@ -297,7 +297,7 @@ public partial class View // Command APIs
         // Report as not handled when Accept originated from a local key binding (e.g., Enter key)
         // on a non-IAcceptTarget view with no redirect - this allows the key to propagate up
         // the view hierarchy to reach a SuperView that can redirect to DefaultAcceptView.
-        return redirected || acceptWillBubble || ctx?.IsBubblingUp == true || this is IAcceptTarget;
+        return redirected || acceptWillBubble || ctx?.Routing == CommandRouting.BubblingUp || this is IAcceptTarget;
     }
 
 
@@ -458,7 +458,7 @@ public partial class View // Command APIs
         // Composite views with ConsumeDispatch=true already completed above (RaiseActivating returned true).
         // Composite views with ConsumeDispatch=false (relay) defer completion — they use the
         // dispatch target's Activated event to fire their own RaiseActivated after the originator completes.
-        if (ctx?.IsBubblingUp == true)
+        if (ctx?.Routing == CommandRouting.BubblingUp)
         {
             return false;
         }
@@ -794,11 +794,11 @@ public partial class View // Command APIs
         if (ConsumeDispatch)
         {
             // Consume pattern (OptionSelector, FlagSelector).
-            // When a SubView's command bubbles up (IsBubblingUp), consume without dispatching.
+            // When a SubView's command bubbles up (BubblingUp), consume without dispatching.
             // The composite handles state mutation in OnActivated/OnAccepted.
             // For programmatic/direct invocations, forward to the target via BubbleDown
             // so the target gets activated (matching the old BubbleDown-in-OnActivating behavior).
-            if (ctx?.IsBubblingUp != true)
+            if (ctx?.Routing != CommandRouting.BubblingUp)
             {
                 BubbleDown (target, ctx);
             }
@@ -877,7 +877,7 @@ public partial class View // Command APIs
 
     /// <summary>
     ///     Dispatches a command downward to a SubView with bubbling suppressed. Creates a new
-    ///     <see cref="CommandContext"/> with <see cref="ICommandContext.IsBubblingDown"/> set to <see langword="true"/>,
+    ///     <see cref="CommandContext"/> with <see cref="ICommandContext.Routing"/> set to <see cref="CommandRouting.DispatchingDown"/>,
     ///     which causes <see cref="TryBubbleUp"/> to skip bubbling on the target, preventing re-entry.
     /// </summary>
     /// <param name="target">The SubView to dispatch the command to.</param>
@@ -889,7 +889,7 @@ public partial class View // Command APIs
     {
         // Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
 
-        CommandContext downCtx = new (ctx?.Command ?? Command.NotBound, ctx?.Source, ctx?.Binding) { IsBubblingDown = true };
+        CommandContext downCtx = new (ctx?.Command ?? Command.NotBound, ctx?.Source, ctx?.Binding) { Routing = CommandRouting.DispatchingDown };
 
         return target.InvokeCommand (downCtx.Command, downCtx);
     }
@@ -923,7 +923,7 @@ public partial class View // Command APIs
             return true;
         }
 
-        if (ctx?.IsBubblingDown == true)
+        if (ctx?.Routing == CommandRouting.DispatchingDown)
         {
             return false;
         }
@@ -949,7 +949,7 @@ public partial class View // Command APIs
                         return false;
                     }
 
-                    CommandContext upCtx = new (Command.Accept, ctx.Source, ctx.Binding) { IsBubblingUp = true };
+                    CommandContext upCtx = new (Command.Accept, ctx.Source, ctx.Binding) { Routing = CommandRouting.BubblingUp };
 
                     // DefaultAcceptView redirect is a special case — it IS a consumption (not just a notification)
                     return SuperView?.InvokeCommand (Command.Accept, upCtx) is true;
@@ -963,7 +963,7 @@ public partial class View // Command APIs
         if (SuperView?.CommandsToBubbleUp.Contains (ctx!.Command) == true)
         {
             // Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
-            CommandContext upCtx = new (ctx?.Command ?? Command.NotBound, ctx?.Source, ctx?.Binding) { IsBubblingUp = true };
+            CommandContext upCtx = new (ctx?.Command ?? Command.NotBound, ctx?.Source, ctx?.Binding) { Routing = CommandRouting.BubblingUp };
 
             return SuperView.InvokeCommand (upCtx.Command, upCtx);
         }
@@ -974,7 +974,7 @@ public partial class View // Command APIs
             if (padding.Parent?.CommandsToBubbleUp.Contains (ctx!.Command) == true)
             {
                 // Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
-                CommandContext upCtx = new (ctx?.Command ?? Command.NotBound, ctx?.Source, ctx?.Binding) { IsBubblingUp = true };
+                CommandContext upCtx = new (ctx?.Command ?? Command.NotBound, ctx?.Source, ctx?.Binding) { Routing = CommandRouting.BubblingUp };
 
                 return padding.Parent.InvokeCommand (upCtx.Command, upCtx);
             }
@@ -984,7 +984,7 @@ public partial class View // Command APIs
         if (this is Padding selfPadding && selfPadding.Parent?.CommandsToBubbleUp.Contains (ctx!.Command) == true)
         {
             // Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
-            CommandContext upCtx = new (ctx?.Command ?? Command.NotBound, ctx?.Source, ctx?.Binding) { IsBubblingUp = true };
+            CommandContext upCtx = new (ctx?.Command ?? Command.NotBound, ctx?.Source, ctx?.Binding) { Routing = CommandRouting.BubblingUp };
 
             return selfPadding.Parent.InvokeCommand (upCtx.Command, upCtx);
         }

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -249,6 +249,12 @@ public partial class View // Command APIs
 
         if (RaiseAccepting (ctx) is true)
         {
+            // If dispatch consumed the command, the composite view needs completion.
+            if (_lastDispatchOccurred)
+            {
+                RaiseAccepted (ctx);
+            }
+
             return true;
         }
 
@@ -270,6 +276,14 @@ public partial class View // Command APIs
         {
             BubbleDown (defaultAcceptView, ctx);
             redirected = true;
+        }
+
+        // Composite views with dispatch targets always get completion on bubble.
+        if (ctx?.IsBubblingUp == true && GetDispatchTarget (ctx) is { })
+        {
+            RaiseAccepted (ctx);
+
+            return false;
         }
 
         // Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx}) - Calling RaiseAccepted");
@@ -328,6 +342,12 @@ public partial class View // Command APIs
             // If the event is not canceled by the virtual method, raise the event to notify any external subscribers.
             //Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx?.Source?.Title}) - Raising Accepting...");
             Accepting?.Invoke (this, args);
+        }
+
+        // Framework dispatch: composite views delegate commands to a target SubView.
+        if (!args.Handled)
+        {
+            args.Handled = TryDispatchToTarget (ctx);
         }
 
         if (!args.Handled)
@@ -421,6 +441,12 @@ public partial class View // Command APIs
 
         if (RaiseActivating (ctx) is true)
         {
+            // If dispatch consumed the command, the composite view needs completion.
+            if (_lastDispatchOccurred)
+            {
+                RaiseActivated (ctx);
+            }
+
             return true;
         }
 
@@ -429,8 +455,9 @@ public partial class View // Command APIs
         // The originating view completes its own activation. Returning false tells TryBubbleUp
         // "not consumed" so the originator continues.
         //
-        // Views that need to CONSUME the activation (e.g., SelectorBase) override OnActivating
-        // to apply state changes and return true, which stops processing before reaching here.
+        // Composite views with ConsumeDispatch=true already completed above (RaiseActivating returned true).
+        // Composite views with ConsumeDispatch=false (relay) defer completion — they use the
+        // dispatch target's Activated event to fire their own RaiseActivated after the originator completes.
         if (ctx?.IsBubblingUp == true)
         {
             return false;
@@ -441,7 +468,13 @@ public partial class View // Command APIs
             SetFocus ();
         }
 
-        RaiseActivated (ctx);
+        // For relay dispatch (ConsumeDispatch=false), the dispatch target's Activated event
+        // already fired RaiseActivated via the deferred completion callback (e.g., CommandView_Activated
+        // in Shortcut). Skip duplicate RaiseActivated.
+        if (!_lastDispatchOccurred)
+        {
+            RaiseActivated (ctx);
+        }
 
         return true;
     }
@@ -501,6 +534,12 @@ public partial class View // Command APIs
         // If the event is not canceled by the virtual method, raise the event to notify any external subscribers.
         // Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx}) - Invoking Activating event");
         Activating?.Invoke (this, args);
+
+        // Framework dispatch: composite views delegate commands to a target SubView.
+        if (!args.Handled)
+        {
+            args.Handled = TryDispatchToTarget (ctx);
+        }
 
         if (!args.Handled)
         {
@@ -669,6 +708,133 @@ public partial class View // Command APIs
     #endregion HotKey
 
     #endregion Default Event Handlers
+
+    #region Dispatch (Composite Pattern)
+
+    /// <summary>
+    ///     Gets the SubView to dispatch commands to. Return <see langword="null"/> to skip dispatch.
+    ///     The framework calls this during <see cref="RaiseActivating"/>/<see cref="RaiseAccepting"/>
+    ///     after the <c>OnXxxing</c> virtual and <c>Xxxing</c> event have had a chance to cancel.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Override this in composite views that delegate commands to a primary SubView.
+    ///         For example, <c>Shortcut</c> returns <c>CommandView</c> and selectors return <c>Focused</c>.
+    ///     </para>
+    ///     <para>
+    ///         The framework guards against dispatch when:
+    ///         <list type="bullet">
+    ///             <item>Routing is <see cref="CommandRouting.DispatchingDown"/> (prevents re-entry)</item>
+    ///             <item>No binding exists on the context (programmatic invocation — skip dispatch)</item>
+    ///             <item>The binding source is within the target (prevents loops)</item>
+    ///         </list>
+    ///     </para>
+    /// </remarks>
+    /// <param name="ctx">The command context.</param>
+    /// <returns>The SubView to dispatch to, or <see langword="null"/> to skip dispatch.</returns>
+    protected virtual View? GetDispatchTarget (ICommandContext? ctx) => null;
+
+    /// <summary>
+    ///     If <see langword="true"/>, dispatching to the target consumes the command, preventing the
+    ///     original SubView from completing its own activation/acceptance. If <see langword="false"/>
+    ///     (default), the dispatch is a relay and the original SubView completes normally.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         When <see langword="true"/>, the composite view owns the state mutation. The framework
+    ///         marks the command as handled after dispatch, stopping the originator. The composite's
+    ///         <c>OnActivated</c>/<c>OnAccepted</c> fires to perform the mutation.
+    ///     </para>
+    ///     <para>
+    ///         When <see langword="false"/> (relay), the command is dispatched to the target but not
+    ///         consumed. The originator continues its own activation/acceptance.
+    ///     </para>
+    /// </remarks>
+    protected virtual bool ConsumeDispatch => false;
+
+    /// <summary>
+    ///     Tracks whether a dispatch occurred during the last <see cref="RaiseActivating"/> or
+    ///     <see cref="RaiseAccepting"/> call. Used by <see cref="DefaultActivateHandler"/> and
+    ///     <see cref="DefaultAcceptHandler"/> to determine whether to call <c>RaiseActivated</c>/<c>RaiseAccepted</c>.
+    /// </summary>
+    private bool _lastDispatchOccurred;
+
+    /// <summary>
+    ///     Attempts to dispatch the command to the <see cref="GetDispatchTarget"/> view.
+    ///     For <see cref="ConsumeDispatch"/>=false (relay), performs a <see cref="BubbleDown"/>.
+    ///     For <see cref="ConsumeDispatch"/>=true (consume), marks the command as handled without dispatching.
+    /// </summary>
+    /// <returns><see langword="true"/> if the command was consumed (ConsumeDispatch=true and dispatch conditions met).</returns>
+    private bool TryDispatchToTarget (ICommandContext? ctx)
+    {
+        _lastDispatchOccurred = false;
+
+        View? target = GetDispatchTarget (ctx);
+
+        if (target is null)
+        {
+            return false;
+        }
+
+        // Guard: don't dispatch if already dispatching down (prevents re-entry)
+        if (ctx?.Routing == CommandRouting.DispatchingDown)
+        {
+            return false;
+        }
+
+        // Guard: don't dispatch for programmatic invocations (no binding)
+        if (ctx?.Binding is null)
+        {
+            return false;
+        }
+
+        if (ConsumeDispatch)
+        {
+            // Consume pattern (OptionSelector, FlagSelector): mark as handled without dispatching.
+            // The composite handles state mutation in OnActivated/OnAccepted.
+            _lastDispatchOccurred = true;
+
+            return true;
+        }
+
+        // Relay pattern (Shortcut): dispatch to target if source is not within target.
+        if (!IsSourceWithinView (target, ctx))
+        {
+            BubbleDown (target, ctx);
+        }
+
+        _lastDispatchOccurred = true;
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Checks whether the binding source of the given context is within the specified view
+    ///     (i.e., is the view itself or a descendant).
+    /// </summary>
+    private static bool IsSourceWithinView (View target, ICommandContext? ctx)
+    {
+        if (ctx?.Binding?.Source is not { } weakSource || !weakSource.TryGetTarget (out View? source))
+        {
+            return false;
+        }
+
+        View? current = source;
+
+        while (current is { })
+        {
+            if (current == target)
+            {
+                return true;
+            }
+
+            current = current.SuperView;
+        }
+
+        return false;
+    }
+
+    #endregion Dispatch (Composite Pattern)
 
     #region Command Bubbling
 

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -782,16 +782,27 @@ public partial class View // Command APIs
             return false;
         }
 
-        // Guard: don't dispatch for programmatic invocations (no binding)
-        if (ctx?.Binding is null)
+        // Guard: for relay dispatch (ConsumeDispatch=false), don't dispatch for programmatic
+        // invocations (no binding). This prevents accidental loops in composite views like Shortcut.
+        // For consume dispatch (ConsumeDispatch=true), programmatic invocations DO dispatch because
+        // the composite view forwards commands to the focused SubView.
+        if (!ConsumeDispatch && ctx?.Binding is null)
         {
             return false;
         }
 
         if (ConsumeDispatch)
         {
-            // Consume pattern (OptionSelector, FlagSelector): mark as handled without dispatching.
+            // Consume pattern (OptionSelector, FlagSelector).
+            // When a SubView's command bubbles up (IsBubblingUp), consume without dispatching.
             // The composite handles state mutation in OnActivated/OnAccepted.
+            // For programmatic/direct invocations, forward to the target via BubbleDown
+            // so the target gets activated (matching the old BubbleDown-in-OnActivating behavior).
+            if (ctx?.IsBubblingUp != true)
+            {
+                BubbleDown (target, ctx);
+            }
+
             _lastDispatchOccurred = true;
 
             return true;

--- a/Terminal.Gui/ViewBase/View.Keyboard.cs
+++ b/Terminal.Gui/ViewBase/View.Keyboard.cs
@@ -603,7 +603,7 @@ public partial class View // Keyboard APIs
 
         // Logging.Debug ($"{this.ToIdentifyingString ()} ({binding})");
 
-        return InvokeCommands (binding.Commands, binding with { Source = this });
+        return InvokeCommands (binding.Commands, binding with { Source = new WeakReference<View> (this) });
     }
 
     /// <summary>
@@ -634,7 +634,7 @@ public partial class View // Keyboard APIs
                 binding.Key = hotKey;
             }
 
-            if (InvokeCommands (binding.Commands, binding with { Source = this }) is true)
+            if (InvokeCommands (binding.Commands, binding with { Source = new WeakReference<View> (this) }) is true)
             {
                 return true;
             }

--- a/Terminal.Gui/Views/Menu/Menu.cs
+++ b/Terminal.Gui/Views/Menu/Menu.cs
@@ -73,7 +73,7 @@ public class Menu : Bar
 
                 // When a MenuItem is activated (e.g., via HotKey → Activate flow),
                 // raise Accepted on this Menu so PopoverMenu can close.
-                menuItem.Activated += (_, e) => RaiseAccepted (e.Value);
+                //menuItem.Activated += (_, e) => RaiseAccepted (e.Value);
 
                 break;
             }

--- a/Terminal.Gui/Views/Menu/MenuBar.cs
+++ b/Terminal.Gui/Views/Menu/MenuBar.cs
@@ -193,7 +193,7 @@ public class MenuBar : Menu, IDesignable
     /// <returns><see langword="true"/> if the popover was hidden</returns>
     public bool HideItem (MenuBarItem? activeItem)
     {
-        // Logging.Debug ($"{this.ToIdentifyingString ()} ({activeItem?.Title}) - Active: {Active}, CanFocus: {CanFocus}, HasFocus: {HasFocus}");
+        Logging.Debug ($"{this.ToIdentifyingString ()} {activeItem?.ToIdentifyingString ()}");
 
         if (activeItem is null || !activeItem.PopoverMenu!.Visible)
         {
@@ -272,6 +272,8 @@ public class MenuBar : Menu, IDesignable
     /// <inheritdoc/>
     protected override bool OnActivating (CommandEventArgs args)
     {
+        Logging.Debug ($"{this.ToIdentifyingString ()} {args}");
+
         // Mouse click (LeftButtonReleased) on a MenuBarItem triggers Activate.
         // The source may be a SubView of the MenuBarItem (e.g., CommandView), so walk up the SuperView chain.
         if (!Visible || !Enabled || args.Context?.Source?.TryGetTarget (out View? sourceView) != true)
@@ -496,7 +498,7 @@ public class MenuBar : Menu, IDesignable
     /// <param name="menuBarItem"></param>
     private void ShowItem (MenuBarItem? menuBarItem)
     {
-        // Logging.Debug ($"{this.ToIdentifyingString ()} - {menuBarItem?.Id}");
+        Logging.Debug ($"{this.ToIdentifyingString ()} {menuBarItem?.ToIdentifyingString ()}");
 
         if (!Active || !Visible)
         {
@@ -515,7 +517,8 @@ public class MenuBar : Menu, IDesignable
         // If the active Application Popover is part of this MenuBar, hide it.
         if (App?.Popover?.GetActivePopover () is PopoverMenu popoverMenu && popoverMenu.Root?.SuperMenuItem?.SuperView == this)
         {
-            // Logging.Debug ($"{this.ToIdentifyingString ()} - Calling App?.Popover?.Hide ({popoverMenu.Title})");
+            Logging.Debug ($"{this.ToIdentifyingString ()} {menuBarItem?.ToIdentifyingString ()} - Calling App?.Popover?.Hide");
+
             App?.Popover.Hide (popoverMenu);
         }
 
@@ -535,9 +538,10 @@ public class MenuBar : Menu, IDesignable
             menuBarItem.PopoverMenu.Root.SchemeName = SchemeName;
         }
 
-        // Logging.Debug ($"{this.ToIdentifyingString ()} - \"{menuBarItem.PopoverMenu?.Title}\".MakeVisible");
         if (menuBarItem.PopoverMenu is { })
         {
+            Logging.Debug ($"{this.ToIdentifyingString ()} {menuBarItem?.ToIdentifyingString ()} - Calling MakeVisible");
+
             menuBarItem.PopoverMenu.App ??= App;
             menuBarItem.PopoverMenu.MakeVisible (new Point (menuBarItem.FrameToScreen ().X, menuBarItem.FrameToScreen ().Bottom));
         }
@@ -548,7 +552,7 @@ public class MenuBar : Menu, IDesignable
 
         void OnMenuItemAccepted (object? sender, EventArgs args)
         {
-            // Logging.Debug ($"{this.ToIdentifyingString ()} - OnMenuItemAccepted");
+            Logging.Debug ($"{this.ToIdentifyingString ()} {args}");
             if (menuBarItem.PopoverMenu is { })
             {
                 menuBarItem.PopoverMenu.VisibleChanged -= OnMenuItemAccepted;
@@ -606,7 +610,11 @@ public class MenuBar : Menu, IDesignable
             CanFocus = false
         };
 
-        OptionSelector<Schemes> mutuallyExclusiveOptionsSelector = new () { Title = "Scheme", CanFocus = true };
+        OptionSelector<Schemes> mutuallyExclusiveOptionsSelector = new ()
+        {
+            Title = "Scheme", CanFocus = true,
+            MouseHighlightStates = MouseState.None
+        };
 
         var menuBgColorCp = new ColorPicker { Width = 30 };
 
@@ -670,7 +678,8 @@ public class MenuBar : Menu, IDesignable
                                                                   Id = "mutuallyExclusiveOptions",
                                                                   HelpText = "Mutually Exclusive Options",
                                                                   CommandView = mutuallyExclusiveOptionsSelector,
-                                                                  Key = Key.F7
+                                                                  Key = Key.F7,
+                                                                  MouseHighlightStates = MouseState.None
                                                               },
                                                               new Line (),
                                                               new MenuItem { HelpText = "MenuBar BG Color", CommandView = menuBgColorCp, Key = Key.F8 }

--- a/Terminal.Gui/Views/Menu/MenuBarItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarItem.cs
@@ -101,6 +101,7 @@ public class MenuBarItem : MenuItem
     public new Menu? SubMenu { get => null; set => throw new InvalidOperationException ("MenuBarItem does not support SubMenu. Use PopoverMenu instead."); }
 
     private PopoverMenu? _popoverMenu;
+    private CommandBridge? _popoverBridge;
 
     /// <summary>
     ///     The Popover Menu that will be displayed when this item is selected.
@@ -118,7 +119,8 @@ public class MenuBarItem : MenuItem
             if (_popoverMenu is { })
             {
                 _popoverMenu.VisibleChanged -= OnPopoverVisibleChanged;
-                _popoverMenu.Accepted -= OnPopoverMenuOnAccepted;
+                _popoverBridge?.Dispose ();
+                _popoverBridge = null;
             }
 
             _popoverMenu = value;
@@ -132,8 +134,9 @@ public class MenuBarItem : MenuItem
 
                 PopoverMenuOpen = _popoverMenu.Visible;
                 _popoverMenu.VisibleChanged += OnPopoverVisibleChanged;
-                _popoverMenu.Accepted += OnPopoverMenuOnAccepted;
-                _popoverMenu.Activated += OnPopoverMenuOnActivated;
+
+                // Bridge Accept from PopoverMenu → MenuBarItem across the non-containment boundary.
+                _popoverBridge = CommandBridge.Connect (this, _popoverMenu, Command.Accept);
             }
 
             return;
@@ -142,18 +145,7 @@ public class MenuBarItem : MenuItem
 
                 // Logging.Debug ($"OnPopoverVisibleChanged - {this.ToIdentifyingString ()} - Visible = {_popoverMenu?.Visible} ");
                 PopoverMenuOpen = _popoverMenu?.Visible ?? false;
-
-            void OnPopoverMenuOnAccepted (object? sender, CommandEventArgs args) =>
-
-                // Logging.Debug ($"OnPopoverMenuOnAccepted - {this.ToIdentifyingString ()} - {args.Context?.Source} - {args.Context?.Command}");
-                RaiseAccepted (args.Context);
         }
-    }
-
-    private void OnPopoverMenuOnActivated (object? sender, EventArgs<ICommandContext?> e)
-    {
-        // Logging.Debug ($"OnPopoverMenuOnActivated - {this.ToIdentifyingString ()} - {e.Value?.Source} - {e.Value?.Command}");
-//        RaiseActivated (e.Value);
     }
 
     private bool _popoverMenuOpen;

--- a/Terminal.Gui/Views/Menu/MenuBarItem.cs
+++ b/Terminal.Gui/Views/Menu/MenuBarItem.cs
@@ -100,7 +100,6 @@ public class MenuBarItem : MenuItem
     /// <exception cref="InvalidOperationException"></exception>
     public new Menu? SubMenu { get => null; set => throw new InvalidOperationException ("MenuBarItem does not support SubMenu. Use PopoverMenu instead."); }
 
-    private PopoverMenu? _popoverMenu;
     private CommandBridge? _popoverBridge;
 
     /// <summary>
@@ -108,35 +107,35 @@ public class MenuBarItem : MenuItem
     /// </summary>
     public PopoverMenu? PopoverMenu
     {
-        get => _popoverMenu;
+        get;
         set
         {
-            if (_popoverMenu == value)
+            if (field == value)
             {
                 return;
             }
 
-            if (_popoverMenu is { })
+            if (field is { })
             {
-                _popoverMenu.VisibleChanged -= OnPopoverVisibleChanged;
+                field.VisibleChanged -= OnPopoverVisibleChanged;
                 _popoverBridge?.Dispose ();
                 _popoverBridge = null;
             }
 
-            _popoverMenu = value;
+            field = value;
 
-            if (_popoverMenu is { })
+            if (field is { })
             {
-                _popoverMenu.App = App;
+                field.App = App;
 #if DEBUG
-                Id = $"{Id}.{_popoverMenu.Id}";
+                Id = $"{Id}.{field.Id}";
 #endif
 
-                PopoverMenuOpen = _popoverMenu.Visible;
-                _popoverMenu.VisibleChanged += OnPopoverVisibleChanged;
+                PopoverMenuOpen = field.Visible;
+                field.VisibleChanged += OnPopoverVisibleChanged;
 
                 // Bridge Accept from PopoverMenu → MenuBarItem across the non-containment boundary.
-                _popoverBridge = CommandBridge.Connect (this, _popoverMenu, Command.Accept);
+                _popoverBridge = CommandBridge.Connect (this, field, Command.Accept);
             }
 
             return;
@@ -144,7 +143,7 @@ public class MenuBarItem : MenuItem
             void OnPopoverVisibleChanged (object? sender, EventArgs args) =>
 
                 // Logging.Debug ($"OnPopoverVisibleChanged - {this.ToIdentifyingString ()} - Visible = {_popoverMenu?.Visible} ");
-                PopoverMenuOpen = _popoverMenu?.Visible ?? false;
+                PopoverMenuOpen = field?.Visible ?? false;
         }
     }
 
@@ -187,7 +186,7 @@ public class MenuBarItem : MenuItem
     /// <inheritdoc/>
     protected override bool OnKeyDownNotHandled (Key key)
     {
-        //Logging.Trace ($"{key}");
+        Logging.Debug ($"{this.ToIdentifyingString ()} ({key})");
 
         if (PopoverMenu is { Visible: true } && HotKeyBindings.TryGet (key, out _))
         {

--- a/Terminal.Gui/Views/Menu/PopoverMenu.cs
+++ b/Terminal.Gui/Views/Menu/PopoverMenu.cs
@@ -322,6 +322,8 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
                 {
                     menu.Accepting -= MenuOnAccepting;
                     menu.Accepted -= MenuAccepted;
+                    menu.Activating -= MenuOnActivating;
+                    menu.Activated -= MenuOnActivated;
                     menu.SelectedMenuItemChanged -= MenuOnSelectedMenuItemChanged;
                 }
             }
@@ -345,6 +347,8 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
                 menu.Visible = false;
                 menu.Accepting += MenuOnAccepting;
                 menu.Accepted += MenuAccepted;
+                menu.Activating += MenuOnActivating;
+                menu.Activated += MenuOnActivated;
                 menu.SelectedMenuItemChanged += MenuOnSelectedMenuItemChanged;
             }
         }
@@ -601,13 +605,15 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
 
     private void MenuOnAccepting (object? sender, CommandEventArgs e)
     {
+        Logging.Debug ($"{this.ToIdentifyingString ()} ({e})");
+
         var senderView = sender as View;
 
         // Logging.Debug ($"{this.ToIdentifyingString ()} ({e.Context?.Source?.Title}) Command: {e.Context?.Command} - Sender: {senderView?.GetType ().Name}");
 
         if (e.Context?.Command != Command.HotKey)
         {
-            // Logging.Debug ($"{this.ToIdentifyingString ()} - Setting Visible = false");
+            Logging.Debug ($"{this.ToIdentifyingString ()} - Setting Visible = false");
             Visible = false;
         }
 
@@ -625,7 +631,7 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
 
     private void MenuAccepted (object? sender, CommandEventArgs e)
     {
-        // Logging.Debug ($"{this.ToIdentifyingString ()} ({e.Context}) Command: {e.Context?.Command}");
+        Logging.Debug ($"{this.ToIdentifyingString ()} ({e})");
 
         if (e.Context?.Source?.TryGetTarget (out View? sourceView) == true)
         {
@@ -641,6 +647,49 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
         RaiseAccepted (e.Context);
     }
 
+
+    private void MenuOnActivating (object? sender, CommandEventArgs e)
+    {
+        Logging.Debug ($"{this.ToIdentifyingString ()} ({e})");
+        var senderView = sender as View;
+
+        // Logging.Debug ($"{this.ToIdentifyingString ()} ({e.Context?.Source?.Title}) Command: {e.Context?.Command} - Sender: {senderView?.GetType ().Name}");
+
+        if (e.Context?.Command != Command.HotKey)
+        {
+            Logging.Debug ($"{this.ToIdentifyingString ()} - Setting Visible = false");
+            Visible = false;
+        }
+
+        if (e.Context?.Binding is not KeyBinding { Key: { } key })
+        {
+            return;
+        }
+
+        if (key == Application.QuitKey && SuperView is { Visible: true })
+        {
+            // Logging.Debug ($"{this.ToIdentifyingString ()} - Setting e.Handled = true - Application.QuitKey/Command = Command.Quit");
+            e.Handled = true;
+        }
+    }
+
+    private void MenuOnActivated (object? sender, EventArgs<ICommandContext?> e)
+    {
+        Logging.Debug ($"{this.ToIdentifyingString ()} ({e})");
+        if (e.Value?.Source?.TryGetTarget (out View? sourceView) == true)
+        {
+            if (sourceView is MenuItem { SubMenu: null })
+            {
+                HideAndRemoveSubMenu (_root);
+            }
+            else if (sourceView is MenuItem { SubMenu: { } } menuItemWithSubMenu)
+            {
+                ShowSubMenu (menuItemWithSubMenu);
+            }
+        }
+        RaiseActivated (e.Value);
+    }
+
     /// <inheritdoc/>
     /// <remarks>
     ///     <para>
@@ -652,7 +701,7 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
     /// </remarks>
     protected override bool OnAccepting (CommandEventArgs args)
     {
-        // Logging.Debug ($"{this.ToIdentifyingString ()} ({args.Context?.Source?.Title}) Command: {args.Context?.Command}");
+        Logging.Debug ($"{this.ToIdentifyingString ()} {args}");
 
         // If we're not visible, ignore any keys that are not hotkeys
 
@@ -660,13 +709,14 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
         {
             if (!GetMenuItemsOfAllSubMenus (i => i.Key == key).Any ())
             {
-                // Logging.Debug ($"{this.ToIdentifyingString ()} ({args.Context?.Source?.Title}) Command: {args.Context?.Command} - ignore any keys that are not hotkeys");
+                Logging.Debug ($"{this.ToIdentifyingString ()} {args} - ignore any keys that are not hotkeys");
 
                 return false;
             }
         }
 
-        // Logging.Debug ($"{this.ToIdentifyingString ()} - calling base.OnAccepting: {args.Context?.Command}");
+        Logging.Debug ($"{this.ToIdentifyingString ()} {args} - calling base.OnAccepting");
+
         bool? ret = base.OnAccepting (args);
 
         if (ret is true || args.Handled)
@@ -677,7 +727,8 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
         // Only raise Accepted if the command came from one of our MenuItems
         // if (GetMenuItemsOfAllSubMenus ().Contains (args.Context?.Source))
         {
-            // Logging.Debug ($"{this.ToIdentifyingString ()} - Calling RaiseAccepted {args.Context?.Command}");
+            Logging.Debug ($"{this.ToIdentifyingString ()} {args} - Calling RaiseAccepted");
+
             RaiseAccepted (args.Context);
         }
 
@@ -685,10 +736,20 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
         return false;
     }
 
-    private void MenuOnSelectedMenuItemChanged (object? sender, MenuItem? e) =>
+    /// <inheritdoc />
+    protected override bool OnActivating (CommandEventArgs args)
+    {
+        Logging.Debug ($"{this.ToIdentifyingString ()} {args}");
 
-        // Logging.Debug ($"{this.ToIdentifyingString ()} - e.Title: {e?.Title}");
+        return base.OnActivating (args);
+    }
+
+    private void MenuOnSelectedMenuItemChanged (object? sender, MenuItem? e)
+    {
+        Logging.Debug ($"{this.ToIdentifyingString ()} {e.ToIdentifyingString ()}");
+
         ShowSubMenu (e);
+    }
 
     /// <inheritdoc/>
     /// <exception cref="InvalidOperationException">
@@ -755,7 +816,8 @@ public class PopoverMenu : PopoverBaseImpl, IDesignable
                              new MenuItem (targetView as View, Command.SelectAll),
                              new Line (),
                              new MenuItem (targetView as View, Command.Quit)
-                         ]) { Title = "Popover Demo Root" };
+                         ])
+        { Title = "Popover Demo Root" };
 
         // NOTE: This is a workaround for the fact that the PopoverMenu is not visible in the designer
         // NOTE: without being activated via App?.Popover. But we want it to be visible.

--- a/Terminal.Gui/Views/Selectors/FlagSelector.cs
+++ b/Terminal.Gui/Views/Selectors/FlagSelector.cs
@@ -33,15 +33,28 @@ public class FlagSelector : SelectorBase, IDesignable
 
     /// <summary>
     ///     Returns the dispatch target for composite command handling.
-    ///     For IsBubblingUp, returns the source CheckBox from the context.
-    ///     For direct invocation, returns the focused CheckBox.
+    ///     Only dispatches for Activate commands — Accept should bubble normally.
     /// </summary>
     protected override View? GetDispatchTarget (ICommandContext? ctx)
     {
+        // Only dispatch Activate, not Accept. Accept should bubble to Menu/MenuBar normally.
+        if (ctx?.Command != Command.Activate)
+        {
+            return null;
+        }
+
         // When a CheckBox's activation bubbles up, the source IS the CheckBox.
-        if (ctx?.Source?.TryGetTarget (out View? source) == true && source is CheckBox)
+        if (ctx.Source?.TryGetTarget (out View? source) == true && source is CheckBox)
         {
             return source;
+        }
+
+        // Suppress dispatch when the HotKey flag is set (HotKey → SetFocus only, no toggle).
+        if (_suppressHotKeyActivate)
+        {
+            _suppressHotKeyActivate = false;
+
+            return null;
         }
 
         return Focused;
@@ -51,6 +64,10 @@ public class FlagSelector : SelectorBase, IDesignable
     ///     Consumes: FlagSelector owns toggle semantics.
     /// </summary>
     protected override bool ConsumeDispatch => true;
+
+    // Set by OnHandlingHotKey to suppress the Activate that DefaultHotKeyHandler
+    // fires after RaiseHandlingHotKey. Checked and cleared in GetDispatchTarget.
+    private bool _suppressHotKeyActivate;
 
     /// <inheritdoc/>
     protected override bool OnHandlingHotKey (CommandEventArgs args)
@@ -66,25 +83,28 @@ public class FlagSelector : SelectorBase, IDesignable
             return true;
         }
 
-        // Not focused: restore focus only. No _suppressHotKeyActivate flag needed —
-        // DefaultHotKeyHandler calls InvokeCommand(Activate) without a binding,
-        // so GetDispatchTarget dispatch is skipped by the framework's
-        // programmatic-invoke guard (binding is null → no dispatch).
+        // Not focused: restore focus, suppress the Activate dispatch that DefaultHotKeyHandler will invoke.
+        _suppressHotKeyActivate = true;
+
         if (CanFocus)
         {
             SetFocus ();
         }
 
+        // Return false so HandlingHotKey event fires (required by AllViews contract)
         return false;
     }
+
+    // _suppressHotKeyActivate is checked and cleared in GetDispatchTarget
 
     /// <inheritdoc/>
     protected override void OnActivated (ICommandContext? ctx)
     {
         base.OnActivated (ctx);
 
-        // Toggle the source CheckBox's value directly.
-        // ConsumeDispatch=true means CheckBox.OnActivated/AdvanceCheckState was suppressed.
+        // Toggle only when the source is a CheckBox (IsBubblingUp path where consume prevented
+        // CheckBox.AdvanceCheckState). For programmatic invocations, BubbleDown already activated
+        // the focused CheckBox and AdvanceCheckState ran, so no additional toggle is needed.
         if (ctx?.Source?.TryGetTarget (out View? source) == true && source is CheckBox checkBox)
         {
             checkBox.Value = checkBox.Value == CheckState.Checked

--- a/Terminal.Gui/Views/Selectors/FlagSelector.cs
+++ b/Terminal.Gui/Views/Selectors/FlagSelector.cs
@@ -29,18 +29,30 @@ public class FlagSelector : SelectorBase, IDesignable
         MouseBindings.Clear ();
     }
 
-    // Set by OnHandlingHotKey to suppress the Activate that DefaultHotKeyHandler
-    // fires after RaiseHandlingHotKey. Checked and cleared in OnActivating.
-    private bool _suppressHotKeyActivate;
+    // ──── Command Coordination ────
 
     /// <summary>
-    ///     Overrides the base method to handle the FlagSelector's HotKey.
-    ///     Per spec: When focused, HotKey is a complete no-op (returns <see langword="true"/> to stop processing).
-    ///     When not focused, restores focus and sets a flag to suppress the Activate that
-    ///     <see cref="View.DefaultHotKeyHandler"/> would otherwise invoke. Returns <see langword="false"/>
-    ///     so the <see cref="View.HandlingHotKey"/> event still fires.
+    ///     Returns the dispatch target for composite command handling.
+    ///     For IsBubblingUp, returns the source CheckBox from the context.
+    ///     For direct invocation, returns the focused CheckBox.
     /// </summary>
-    /// <param name="args">The command event arguments.</param>
+    protected override View? GetDispatchTarget (ICommandContext? ctx)
+    {
+        // When a CheckBox's activation bubbles up, the source IS the CheckBox.
+        if (ctx?.Source?.TryGetTarget (out View? source) == true && source is CheckBox)
+        {
+            return source;
+        }
+
+        return Focused;
+    }
+
+    /// <summary>
+    ///     Consumes: FlagSelector owns toggle semantics.
+    /// </summary>
+    protected override bool ConsumeDispatch => true;
+
+    /// <inheritdoc/>
     protected override bool OnHandlingHotKey (CommandEventArgs args)
     {
         if (base.OnHandlingHotKey (args))
@@ -54,62 +66,14 @@ public class FlagSelector : SelectorBase, IDesignable
             return true;
         }
 
-        // Not focused: restore focus, suppress the Activate that DefaultHotKeyHandler will invoke
-        _suppressHotKeyActivate = true;
-
+        // Not focused: restore focus only. No _suppressHotKeyActivate flag needed —
+        // DefaultHotKeyHandler calls InvokeCommand(Activate) without a binding,
+        // so GetDispatchTarget dispatch is skipped by the framework's
+        // programmatic-invoke guard (binding is null → no dispatch).
         if (CanFocus)
         {
             SetFocus ();
         }
-
-        // Return false so HandlingHotKey event fires (required by AllViews contract)
-        return false;
-    }
-
-    /// <inheritdoc/>
-    protected override bool OnActivating (CommandEventArgs args)
-    {
-        if (base.OnActivating (args) || args.Handled)
-        {
-            return true;
-        }
-
-        Logging.Debug ($"{this.ToIdentifyingString ()} ({args})");
-
-        // HotKey-triggered Activate: OnHandlingHotKey set the flag to suppress toggling
-        if (_suppressHotKeyActivate)
-        {
-            _suppressHotKeyActivate = false;
-
-            return false;
-        }
-
-        // When a CheckBox SubView's activation bubbles up, toggle it and raise Activated
-        // (so Shortcut's deferred activation path completes via CommandView_Activated).
-        // Return true to consume — prevents the originator CheckBox from double-toggling
-        // via AdvanceCheckState.
-        if (args.Context?.IsBubblingUp == true
-            && args.Context.Source?.TryGetTarget (out View? source) == true
-            && source is CheckBox checkBox)
-        {
-            checkBox.Value = checkBox.Value == CheckState.Checked ? CheckState.UnChecked : CheckState.Checked;
-            RaiseActivated (args.Context);
-
-            return true;
-        }
-
-        // Skip BubbleDown when:
-        // - IsBubblingDown is true (re-entry prevention)
-        // - No Focused view to dispatch to
-        // - Source is a SubView that already bubbled up (not this selector)
-        if (args.Context?.IsBubblingDown == true || Focused is null || (args.Context?.TryGetSource (out View? ctxSource) is true && ctxSource != this))
-        {
-            return false;
-        }
-
-        // Programmatic invocation: BubbleDown to the focused checkbox so it activates and toggles.
-        // Return false so FlagSelector.Activating event still fires.
-        BubbleDown (Focused, args.Context);
 
         return false;
     }
@@ -119,9 +83,16 @@ public class FlagSelector : SelectorBase, IDesignable
     {
         base.OnActivated (ctx);
 
-        // No additional toggle here — OnActivating handles the bubble case
-        // and calls RaiseActivated directly. For direct invocations, the
-        // BubbleDown in OnActivating triggers the CheckBox toggle via AdvanceCheckState.
+        // Toggle the source CheckBox's value directly.
+        // ConsumeDispatch=true means CheckBox.OnActivated/AdvanceCheckState was suppressed.
+        if (ctx?.Source?.TryGetTarget (out View? source) == true && source is CheckBox checkBox)
+        {
+            checkBox.Value = checkBox.Value == CheckState.Checked
+                                 ? CheckState.UnChecked
+                                 : CheckState.Checked;
+        }
+
+        // CheckboxOnValueChanged handler updates FlagSelector.Value bitmask
     }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -31,31 +31,28 @@ public class OptionSelector : SelectorBase, IDesignable
         // really wants that.
         base.Value = 0;
 
-    /// <inheritdoc/>
-    protected override bool OnActivating (CommandEventArgs args)
+    // ──── Command Coordination ────
+
+    /// <summary>
+    ///     Returns the dispatch target for composite command handling.
+    ///     For IsBubblingUp, returns the source CheckBox from the context.
+    ///     For direct invocation, returns the focused CheckBox.
+    /// </summary>
+    protected override View? GetDispatchTarget (ICommandContext? ctx)
     {
-        Logging.Debug ($"{this.ToIdentifyingString ()} ({args}");
-
-        if (base.OnActivating (args) || args.Handled)
+        // When a CheckBox's activation bubbles up, the source IS the CheckBox.
+        if (ctx?.Source?.TryGetTarget (out View? source) == true && source is CheckBox)
         {
-            return true;
+            return source;
         }
 
-        // When a CheckBox SubView's activation bubbles up, apply the value change here
-        // and consume the command so the originating CheckBox does not independently toggle
-        // via AdvanceCheckState. DefaultActivateHandler returns false for IsBubblingUp
-        // by default (notification), but OptionSelector returns true (consumption) because
-        // it owns the selection state, not the individual CheckBoxes.
-        if (args.Context?.IsBubblingUp == true)
-        {
-            ApplyActivation (args.Context);
-            RaiseActivated (args.Context);
-
-            return true;
-        }
-
-        return false;
+        return Focused;
     }
+
+    /// <summary>
+    ///     Consumes: OptionSelector owns selection state, not the individual CheckBoxes.
+    /// </summary>
+    protected override bool ConsumeDispatch => true;
 
     /// <inheritdoc/>
     protected override void OnActivated (ICommandContext? ctx)
@@ -63,17 +60,13 @@ public class OptionSelector : SelectorBase, IDesignable
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
         base.OnActivated (ctx);
 
-        // For direct invocations (not bubbling), apply the value change in the completion phase.
-        // Skip when IsBubblingUp — OnActivating already applied the change and called RaiseActivated.
-        if (ctx?.IsBubblingUp != true)
-        {
-            ApplyActivation (ctx);
-        }
+        // Apply the value change. Runs for ALL activation paths uniformly.
+        // No routing-direction check needed — the framework handled dispatch/consumption.
+        ApplyActivation (ctx);
     }
 
     /// <summary>
-    ///     Applies the value change based on the activation source. Shared by both
-    ///     <see cref="OnActivating"/> (for bubble consumption) and <see cref="OnActivated"/> (for direct invocation).
+    ///     Applies the value change based on the activation source.
     /// </summary>
     private void ApplyActivation (ICommandContext? ctx)
     {

--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -65,8 +65,7 @@ public class OptionSelector : SelectorBase, IDesignable
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
         base.OnActivated (ctx);
 
-        // Apply the value change. Runs for ALL activation paths uniformly.
-        // No routing-direction check needed — the framework handled dispatch/consumption.
+        // Apply value change for all activation paths.
         ApplyActivation (ctx);
     }
 
@@ -77,7 +76,22 @@ public class OptionSelector : SelectorBase, IDesignable
     {
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
 
-        if (ctx?.Source?.TryGetTarget (out View? sourceView) != true || sourceView is not CheckBox checkBox)
+        // Determine the target CheckBox based on routing:
+        // - BubblingUp: use ctx.Source (the CheckBox that bubbled)
+        // - DispatchingDown (from Shortcut): use Focused (the CheckBox that has focus)
+        // - Direct/programmatic: Cycle() (advance to next option)
+        CheckBox? checkBox = null;
+
+        if (ctx?.Source?.TryGetTarget (out View? sourceView) == true && sourceView is CheckBox cb)
+        {
+            checkBox = cb;
+        }
+        else if (ctx?.Routing == CommandRouting.DispatchingDown && Focused is CheckBox focusedCb)
+        {
+            checkBox = focusedCb;
+        }
+
+        if (checkBox is null)
         {
             Cycle ();
 

--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -65,7 +65,8 @@ public class OptionSelector : SelectorBase, IDesignable
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
         base.OnActivated (ctx);
 
-        // Apply value change for all activation paths.
+        // Apply the value change. Runs for ALL activation paths uniformly.
+        // No routing-direction check needed — the framework handled dispatch/consumption.
         ApplyActivation (ctx);
     }
 
@@ -76,22 +77,7 @@ public class OptionSelector : SelectorBase, IDesignable
     {
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
 
-        // Determine the target CheckBox based on routing:
-        // - BubblingUp: use ctx.Source (the CheckBox that bubbled)
-        // - DispatchingDown (from Shortcut): use Focused (the CheckBox that has focus)
-        // - Direct/programmatic: Cycle() (advance to next option)
-        CheckBox? checkBox = null;
-
-        if (ctx?.Source?.TryGetTarget (out View? sourceView) == true && sourceView is CheckBox cb)
-        {
-            checkBox = cb;
-        }
-        else if (ctx?.Routing == CommandRouting.DispatchingDown && Focused is CheckBox focusedCb)
-        {
-            checkBox = focusedCb;
-        }
-
-        if (checkBox is null)
+        if (ctx?.Source?.TryGetTarget (out View? sourceView) != true || sourceView is not CheckBox checkBox)
         {
             Cycle ();
 

--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -45,6 +45,8 @@ public class OptionSelector : SelectorBase, IDesignable
             return null;
         }
 
+        Logging.Debug ($"{this.ToIdentifyingString ()} {ctx}");
+
         // When a CheckBox's activation bubbles up, the source IS the CheckBox.
         if (ctx.Source?.TryGetTarget (out View? source) == true && source is CheckBox)
         {

--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -35,13 +35,18 @@ public class OptionSelector : SelectorBase, IDesignable
 
     /// <summary>
     ///     Returns the dispatch target for composite command handling.
-    ///     For IsBubblingUp, returns the source CheckBox from the context.
-    ///     For direct invocation, returns the focused CheckBox.
+    ///     Only dispatches for Activate commands — Accept should bubble normally.
     /// </summary>
     protected override View? GetDispatchTarget (ICommandContext? ctx)
     {
+        // Only dispatch Activate, not Accept. Accept should bubble to Menu/MenuBar normally.
+        if (ctx?.Command != Command.Activate)
+        {
+            return null;
+        }
+
         // When a CheckBox's activation bubbles up, the source IS the CheckBox.
-        if (ctx?.Source?.TryGetTarget (out View? source) == true && source is CheckBox)
+        if (ctx.Source?.TryGetTarget (out View? source) == true && source is CheckBox)
         {
             return source;
         }

--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -77,6 +77,13 @@ public class OptionSelector : SelectorBase, IDesignable
     {
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
 
+        // TODO: When OptionSelector is a CommandView inside a MenuItem/Shortcut and activation
+        // arrives via DispatchingDown from the Shortcut, ctx.Source is the OptionSelector itself
+        // (not the clicked CheckBox). This causes the fallback to Cycle() instead of selecting
+        // the correct item. The root cause is that LeftButtonReleased is not bound on CheckBox
+        // (it uses LeftButtonClicked), so the event propagates to the parent Shortcut which
+        // dispatches down with Source=CommandView. Need to identify the correct CheckBox from
+        // the Focused state or mouse position when Source is not a CheckBox.
         if (ctx?.Source?.TryGetTarget (out View? sourceView) != true || sourceView is not CheckBox checkBox)
         {
             Cycle ();

--- a/Terminal.Gui/Views/Selectors/SelectorBase.cs
+++ b/Terminal.Gui/Views/Selectors/SelectorBase.cs
@@ -176,7 +176,7 @@ public abstract class SelectorBase : View, IOrientation, IValue<int?>
 
         return args.Context?.Binding switch
                {
-                   { Source: { } source } when source == this => true,
+                   { Source: { } weakSource } when weakSource.TryGetTarget (out View? src) && src == this => true,
                    MouseBinding mouseBinding when mouseBinding.MouseEvent!.Flags.HasFlag (MouseFlags.LeftButtonDoubleClicked) => !DoubleClickAccepts,
                    KeyBinding { Key: { } } keyBinding when keyBinding.Key == Key.Enter => false,
                    null => false,

--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -297,7 +297,7 @@ public class Shortcut : View, IOrientation, IDesignable
             // BubbleDown to CommandView now. This happens AFTER the Activating event handler had
             // a chance to cancel (RaiseActivating above). CommandView.Activated will trigger
             // the deferred RaiseActivated via CommandView_Activated.
-            if (ctx.Binding is { Source: { } source } && !IsWithinCommandView (source))
+            if (ctx.Binding is { Source: { } weakSource } && weakSource.TryGetTarget (out View? source) && !IsWithinCommandView (source))
             {
                 BubbleDown (CommandView, ctx);
             }
@@ -350,7 +350,10 @@ public class Shortcut : View, IOrientation, IDesignable
         // Skip when the command bubbled up from CommandView or was directly invoked (no binding).
         // When IsBubblingUp, skip BubbleDown here so the Activating event handler gets a chance
         // to handle/cancel first. The Activate command handler will BubbleDown after if needed.
-        if (args.Context?.IsBubblingUp != true && args.Context?.Binding is { Source: { } source } && !IsWithinCommandView (source))
+        if (args.Context?.IsBubblingUp != true
+            && args.Context?.Binding is { Source: { } weakSource }
+            && weakSource.TryGetTarget (out View? source)
+            && !IsWithinCommandView (source))
         {
             return BubbleDown (CommandView, args.Context) is null;
         }
@@ -366,13 +369,15 @@ public class Shortcut : View, IOrientation, IDesignable
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx}) - Invoke Action...");
         Action?.Invoke ();
 
-        // Translate the incoming command to Command
-        if (Command != Command.NotBound && ctx is { })
+        // Translate the incoming command to Command via immutable context
+        ICommandContext? targetCtx = ctx;
+
+        if (Command != Command.NotBound && ctx is CommandContext cc)
         {
-            ctx.Command = Command;
+            targetCtx = cc.WithCommand (Command);
         }
 
-        InvokeOnTargetOrApp (ctx);
+        InvokeOnTargetOrApp (targetCtx);
     }
 
     private void InvokeOnTargetOrApp (ICommandContext? ctx)
@@ -410,7 +415,7 @@ public class Shortcut : View, IOrientation, IDesignable
         // Only bubble down to CommandView when accept came from user interaction
         // with this Shortcut or its non-CommandView SubViews (HelpView/KeyView).
         // Skip when the command bubbled up from CommandView or was directly invoked (no binding).
-        if (args.Context?.Binding is { Source: { } source } && !IsWithinCommandView (source))
+        if (args.Context?.Binding is { Source: { } weakSource } && weakSource.TryGetTarget (out View? source) && !IsWithinCommandView (source))
         {
             return BubbleDown (CommandView, args.Context) is null;
         }
@@ -425,13 +430,15 @@ public class Shortcut : View, IOrientation, IDesignable
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx}) - Invoke Action...");
         Action?.Invoke ();
 
-        // Translate the incoming command to Command
-        if (Command != Command.NotBound && ctx is { })
+        // Translate the incoming command to Command via immutable context
+        ICommandContext? targetCtx = ctx;
+
+        if (Command != Command.NotBound && ctx is CommandContext cc)
         {
-            ctx.Command = Command;
+            targetCtx = cc.WithCommand (Command);
         }
 
-        InvokeOnTargetOrApp (ctx);
+        InvokeOnTargetOrApp (targetCtx);
     }
 
     /// <summary>

--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -85,7 +85,9 @@ public class Shortcut : View, IOrientation, IDesignable
 
         CommandsToBubbleUp = [Command.Activate, Command.Accept];
 
-        AddCommand (Command.Activate, HandleActivate);
+        // NOTE: No AddCommand (Command.Activate, HandleActivate).
+        // The framework calls GetDispatchTarget and handles dispatch/deferred-completion
+        // automatically via the default handlers.
 
         TitleChanged += Shortcut_TitleChanged; // This needs to be set before CommandView is set
 
@@ -263,107 +265,22 @@ public class Shortcut : View, IOrientation, IDesignable
     #region Accept/Activate/HotKey Command Handling
 
     /// <summary>
-    ///     Override the default Activate handler. When a SubView's Activate bubbles up to this
-    ///     Shortcut (IsBubblingUp=true), we return false so the originating SubView's
-    ///     DefaultActivateHandler continues to call RaiseActivated (e.g., CheckBox needs this to
-    ///     toggle its state). Without this, the SuperView consuming the command would prevent
-    ///     the SubView from completing its own activation.
+    ///     Shortcut dispatches all commands to <see cref="CommandView"/>. The framework handles:
+    ///     <list type="bullet">
+    ///         <item>Source guard (skip if source is already within CommandView)</item>
+    ///         <item>Programmatic guard (skip if no binding)</item>
+    ///         <item>Deferred completion (Shortcut.Activated fires after CommandView.Activated)</item>
+    ///     </list>
     /// </summary>
-    /// <param name="ctx"></param>
-    /// <returns></returns>
-    private bool? HandleActivate (ICommandContext? ctx)
-    {
-        _activationBubbledUp = false;
+    protected override View? GetDispatchTarget (ICommandContext? ctx) => CommandView;
 
-        Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx})");
-
-        if (RaiseActivating (ctx) is true)
-        {
-            return true;
-        }
-
-        if (CanFocus)
-        {
-            SetFocus ();
-        }
-
-        if (ctx?.IsBubblingUp == true)
-        {
-            // Defer RaiseActivated until CommandView.Activated fires.
-            _activationBubbledUp = true;
-            _deferredActivationContext = ctx;
-
-            // If activation bubbled up from a non-CommandView SubView (e.g., HelpView/KeyView),
-            // BubbleDown to CommandView now. This happens AFTER the Activating event handler had
-            // a chance to cancel (RaiseActivating above). CommandView.Activated will trigger
-            // the deferred RaiseActivated via CommandView_Activated.
-            if (ctx.Binding is { Source: { } weakSource } && weakSource.TryGetTarget (out View? source) && !IsWithinCommandView (source))
-            {
-                BubbleDown (CommandView, ctx);
-            }
-
-            return false;
-        }
-
-        RaiseActivated (ctx);
-
-        return true;
-    }
-
-    /// <summary>
-    ///     Checks whether the specified view is the <see cref="CommandView"/> or a descendant of it.
-    ///     Used to determine if a command originated from within the CommandView hierarchy,
-    ///     in which case BubbleDown should be skipped (the activation already came from CommandView).
-    /// </summary>
-    private bool IsWithinCommandView (View source)
-    {
-        View? v = source;
-
-        while (v is { })
-        {
-            if (v == CommandView)
-            {
-                return true;
-            }
-
-            v = v.SuperView;
-        }
-
-        return false;
-    }
-
-    private bool _activationBubbledUp;
-    private ICommandContext? _deferredActivationContext;
-
-    /// <inheritdoc/>
-    protected override bool OnActivating (CommandEventArgs args)
-    {
-        if (base.OnActivating (args))
-        {
-            return true;
-        }
-
-        Logging.Debug ($"{this.ToIdentifyingString ()} ({args})");
-
-        // Only bubble down to CommandView when the activation came from user interaction
-        // with this Shortcut or its non-CommandView SubViews (HelpView/KeyView).
-        // Skip when the command bubbled up from CommandView or was directly invoked (no binding).
-        // When IsBubblingUp, skip BubbleDown here so the Activating event handler gets a chance
-        // to handle/cancel first. The Activate command handler will BubbleDown after if needed.
-        if (args.Context?.IsBubblingUp != true
-            && args.Context?.Binding is { Source: { } weakSource }
-            && weakSource.TryGetTarget (out View? source)
-            && !IsWithinCommandView (source))
-        {
-            return BubbleDown (CommandView, args.Context) is null;
-        }
-
-        return false;
-    }
+    // ConsumeDispatch defaults to false — CommandView completes its own activation
+    // (e.g., CheckBox.OnActivated calls AdvanceCheckState).
 
     /// <inheritdoc/>
     protected override void OnActivated (ICommandContext? ctx)
     {
+        _activatedFiredThisCycle = true;
         base.OnActivated (ctx);
 
         Logging.Debug ($"{this.ToIdentifyingString ()} ({ctx}) - Invoke Action...");
@@ -400,27 +317,6 @@ public class Shortcut : View, IOrientation, IDesignable
         // Is this an Application-bound command?
         Logging.Debug ($"{this.ToIdentifyingString ()} - Application.InvokeCommandsBoundToKey ({Key})...");
         App?.Keyboard.InvokeCommandsBoundToKey (Key);
-    }
-
-    /// <inheritdoc/>
-    protected override bool OnAccepting (CommandEventArgs args)
-    {
-        if (base.OnAccepting (args))
-        {
-            return true;
-        }
-
-        Logging.Debug ($"{this.ToIdentifyingString ()} ({args})");
-
-        // Only bubble down to CommandView when accept came from user interaction
-        // with this Shortcut or its non-CommandView SubViews (HelpView/KeyView).
-        // Skip when the command bubbled up from CommandView or was directly invoked (no binding).
-        if (args.Context?.Binding is { Source: { } weakSource } && weakSource.TryGetTarget (out View? source) && !IsWithinCommandView (source))
-        {
-            return BubbleDown (CommandView, args.Context) is null;
-        }
-
-        return false;
     }
 
     /// <inheritdoc/>
@@ -641,24 +537,24 @@ public class Shortcut : View, IOrientation, IDesignable
         // CommandView is public and replaceable, but this is a convenience.
         _commandView.Text = Title;
 
+    // Tracks whether Shortcut.RaiseActivated already fired during the current activation
+    // cycle (from DefaultActivateHandler's direct path). Prevents double-firing when
+    // CommandView.Activated would also trigger it.
+    private bool _activatedFiredThisCycle;
+
+    /// <summary>
+    ///     Deferred completion: when CommandView.Activated fires (e.g., CheckBox toggled),
+    ///     fire RaiseActivated on the Shortcut so Action and InvokeOnTargetOrApp run
+    ///     AFTER the CommandView has finished its own activation.
+    /// </summary>
     private void CommandView_Activated (object? sender, EventArgs<ICommandContext?> e)
     {
-        if (_activationBubbledUp)
+        if (!_activatedFiredThisCycle)
         {
-            // Deferred path: HandleActivate ran and deferred RaiseActivated.
-            _activationBubbledUp = false;
-            ICommandContext? ctx = _deferredActivationContext;
-            _deferredActivationContext = null;
-
-            RaiseActivated (ctx);
-        }
-        else if (e.Value?.IsBubblingUp == true)
-        {
-            // CommandView consumed the bubble in OnActivating (e.g., FlagSelector/OptionSelector)
-            // before it reached HandleActivate. The CommandView called RaiseActivated directly,
-            // so complete the Shortcut's activation now.
             RaiseActivated (e.Value);
         }
+
+        _activatedFiredThisCycle = false;
     }
 
     /// <summary>

--- a/Tests/IntegrationTests/FluentTests/MenuBarvTests.cs
+++ b/Tests/IntegrationTests/FluentTests/MenuBarvTests.cs
@@ -467,6 +467,91 @@ public class MenuBarTests : TestsAllDrivers
 
     // Claude - Opus 4.6
     /// <summary>
+    ///     Tests a Bar with Shortcuts as the CommandView of a MenuItem in a PopoverMenu.
+    ///     Clicks on the second Shortcut's text area to verify the correct Shortcut activates
+    ///     (not Cycle or wrong dispatch). This tests whether the dispatch issue is general
+    ///     to compound CommandViews, not specific to OptionSelector.
+    /// </summary>
+    [Fact]
+    public void Bar_CommandView_In_Menu_Click_Activates_Correct_Shortcut ()
+    {
+        string d = "ansi";
+        IApplication? app = null;
+        MenuBar? menuBar = null;
+        var shortcut1ActivatedCount = 0;
+        var shortcut2ActivatedCount = 0;
+        var shortcut3ActivatedCount = 0;
+        Shortcut? shortcut2 = null;
+
+        TestContext c = With.A<Window> (80, 30, d, _out)
+                            .Then (a =>
+                                   {
+                                       app = a;
+
+                                       Shortcut s1 = new () { Title = "First", Key = Key.F1, Id = "s1" };
+                                       s1.Activated += (_, _) => shortcut1ActivatedCount++;
+
+                                       shortcut2 = new Shortcut { Title = "Second", Key = Key.F2, Id = "s2" };
+                                       shortcut2.Activated += (_, _) => shortcut2ActivatedCount++;
+
+                                       Shortcut s3 = new () { Title = "Third", Key = Key.F3, Id = "s3" };
+                                       s3.Activated += (_, _) => shortcut3ActivatedCount++;
+
+                                       Bar bar = new () { Orientation = Orientation.Vertical };
+                                       bar.Add (s1, shortcut2, s3);
+
+                                       menuBar = new MenuBar
+                                       {
+                                           Menus =
+                                           [
+                                               new MenuBarItem ("_Test",
+                                                                [
+                                                                    new MenuItem
+                                                                    {
+                                                                        Id = "barItem",
+                                                                        HelpText = "Bar with shortcuts",
+                                                                        CommandView = bar
+                                                                    }
+                                                                ])
+                                           ]
+                                       };
+
+                                       app.TopRunnableView!.Add (menuBar);
+                                   });
+
+        c = c.WaitIteration ();
+
+        // Open the menu
+        c = c.KeyDown (MenuBar.DefaultKey);
+        Assert.True (menuBar!.IsOpen (), "Menu should be open after F9");
+
+        c = c.ScreenShot ("Menu open with Bar CommandView", _out);
+
+        // Click on the second shortcut ("Second")
+        var screenX = 0;
+        var screenY = 0;
+
+        c = c.Then (_ =>
+                    {
+                        System.Drawing.Point pos = shortcut2!.FrameToScreen ().Location;
+                        screenX = pos.X + 1; // offset into the text area
+                        screenY = pos.Y;
+                    });
+
+        c = c.LeftClick (screenX, screenY);
+
+        c = c.ScreenShot ("After clicking Second shortcut", _out);
+
+        // Assert — only the second shortcut should activate
+        Assert.Equal (0, shortcut1ActivatedCount);
+        Assert.True (shortcut2ActivatedCount >= 1, $"shortcut2 Activated should fire (fired {shortcut2ActivatedCount} times)");
+        Assert.Equal (0, shortcut3ActivatedCount);
+
+        c.Dispose ();
+    }
+
+    // Claude - Opus 4.6
+    /// <summary>
     ///     Simpler variant: OptionSelector directly in the root Menu (no SubMenu nesting).
     ///     Isolates whether the bug is SubMenu-specific or general to PopoverMenu.
     /// </summary>

--- a/Tests/IntegrationTests/FluentTests/MenuBarvTests.cs
+++ b/Tests/IntegrationTests/FluentTests/MenuBarvTests.cs
@@ -374,6 +374,175 @@ public class MenuBarTests : TestsAllDrivers
                                   .AssertTrue (app?.TopRunnable!.IsRunning);
     }
 
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     Verifies that clicking the "Error" checkbox in the OptionSelector&lt;Schemes&gt;
+    ///     inside File → Preferences SubMenu changes Value from Base (0) to Error (4).
+    ///     Exercises the full Shortcut → OptionSelector dispatch path inside a PopoverMenu SubMenu.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_SubMenu_Click_Sets_Correct_Value ()
+    {
+        string d = "ansi";
+        MenuBar? menuBar = null;
+        IApplication? app = null;
+        OptionSelector<Schemes>? optionSelector = null;
+        Schemes? capturedNewValue = null;
+        var valueChangedCount = 0;
+
+        // Step 1: Set up MenuBar with EnableForDesign
+        TestContext c = With.A<Window> (80, 30, d, _out)
+                            .Then (a =>
+                                   {
+                                       app = a;
+                                       menuBar = new MenuBar ();
+                                       View top = app.TopRunnableView!;
+                                       top.Add (new View { CanFocus = true, Id = "focusableView" });
+                                       menuBar.EnableForDesign (ref top);
+                                       app.TopRunnableView!.Add (menuBar);
+                                   });
+
+        c = c.WaitIteration ();
+
+        // Step 2: Open the File menu via F9 then verify it's open
+        c = c.KeyDown (MenuBar.DefaultKey);
+        Assert.True (menuBar!.IsOpen (), "File menu should be open after F9");
+
+        // Step 3: Navigate down to "Preferences" (it's after several items + a Line)
+        // File menu items: New, Open, Save, SaveAs, Line, FileOptions, Line, Preferences, Line, Quit
+        c = c.KeyDown (Key.CursorDown); // New → Open
+        c = c.KeyDown (Key.CursorDown); // Open → Save
+        c = c.KeyDown (Key.CursorDown); // Save → SaveAs
+        c = c.KeyDown (Key.CursorDown); // SaveAs → (skips Line) → File Options
+        c = c.KeyDown (Key.CursorDown); // File Options → (skips Line) → Preferences
+
+        // Step 4: Open the Preferences SubMenu by pressing Right or Enter
+        c = c.KeyDown (Key.CursorRight);
+
+        // Step 5: Find the OptionSelector and subscribe to ValueChanged
+        c = c.Then (_ =>
+                    {
+                        // Find the mutuallyExclusiveOptions MenuItem
+                        IEnumerable<MenuItem> allMenuItems = menuBar!.GetMenuItemsWith (mi => mi.Id == "mutuallyExclusiveOptions");
+                        MenuItem? optionMenuItem = allMenuItems.FirstOrDefault ();
+                        Assert.NotNull (optionMenuItem);
+
+                        optionSelector = optionMenuItem!.CommandView as OptionSelector<Schemes>;
+                        Assert.NotNull (optionSelector);
+                        Assert.Equal (Schemes.Base, optionSelector!.Value);
+
+                        optionSelector.ValueChanged += (_, args) =>
+                                                       {
+                                                           capturedNewValue = args.Value;
+                                                           valueChangedCount++;
+                                                       };
+                    });
+
+        // Step 6: Click directly on the Error checkbox WITHOUT keyboard navigation first.
+        // This simulates the real user scenario where the user opens the menu and clicks
+        // directly on a checkbox without using arrow keys.
+        CheckBox? errorCheckBox = null;
+        var errorScreenX = 0;
+        var errorScreenY = 0;
+
+        c = c.Then (_ =>
+                    {
+                        errorCheckBox = optionSelector!.SubViews.OfType<CheckBox> ()
+                                                       .FirstOrDefault (cb => (int)cb.Data! == (int)Schemes.Error);
+                        Assert.NotNull (errorCheckBox);
+                        System.Drawing.Point pos = errorCheckBox!.FrameToScreen ().Location;
+                        errorScreenX = pos.X;
+                        errorScreenY = pos.Y;
+                    });
+
+        c = c.LeftClick (errorScreenX, errorScreenY);
+
+        c = c.ScreenShot ("After clicking Error (full driver sequence)", _out);
+
+        // Assert — Value should change from Base (0) to Error (4), not to Menu (1)
+        Assert.Equal (Schemes.Error, optionSelector!.Value);
+
+        c.Dispose ();
+    }
+
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     Simpler variant: OptionSelector directly in the root Menu (no SubMenu nesting).
+    ///     Isolates whether the bug is SubMenu-specific or general to PopoverMenu.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_RootMenu_Space_Sets_Correct_Value ()
+    {
+        string d = "ansi";
+        MenuBar? menuBar = null;
+        IApplication? app = null;
+        OptionSelector<Schemes>? optionSelector = null;
+        Schemes? capturedNewValue = null;
+        var valueChangedCount = 0;
+
+        // Step 1: Build a simple MenuBar with an OptionSelector directly in the root Menu
+        TestContext c = With.A<Window> (80, 30, d, _out)
+                            .Then (a =>
+                                   {
+                                       app = a;
+
+                                       optionSelector = new OptionSelector<Schemes> { Title = "Scheme", CanFocus = true };
+
+                                       menuBar = new MenuBar
+                                       {
+                                           Menus =
+                                           [
+                                               new MenuBarItem ("_Test",
+                                                                [
+                                                                    new MenuItem
+                                                                    {
+                                                                        Id = "selectorItem",
+                                                                        HelpText = "Pick a scheme",
+                                                                        CommandView = optionSelector
+                                                                    }
+                                                                ])
+                                           ]
+                                       };
+
+                                       app.TopRunnableView!.Add (menuBar);
+
+                                       optionSelector.ValueChanged += (_, args) =>
+                                                                      {
+                                                                          capturedNewValue = args.Value;
+                                                                          valueChangedCount++;
+                                                                      };
+                                   });
+
+        c = c.WaitIteration ();
+
+        // Step 2: Open the Test menu
+        c = c.KeyDown (MenuBar.DefaultKey);
+        Assert.True (menuBar!.IsOpen (), "Menu should be open after F9");
+
+        c = c.ScreenShot ("After F9 - menu open", _out);
+
+        // Step 3: Navigate within the OptionSelector to Error
+        // Items: Base(0), Menu(1), Dialog(2), Runnable(3), Error(4)
+        c = c.KeyDown (Key.CursorDown); // Base → Menu
+        c = c.KeyDown (Key.CursorDown); // Menu → Dialog
+        c = c.KeyDown (Key.CursorDown); // Dialog → Runnable
+        c = c.KeyDown (Key.CursorDown); // Runnable → Error
+
+        c = c.ScreenShot ("After navigating to Error", _out);
+
+        // Step 4: Press Space to activate
+        c = c.KeyDown (Key.Space);
+
+        c = c.ScreenShot ("After Space on Error", _out);
+
+        // Step 5: Assert
+        Assert.True (valueChangedCount >= 1, $"ValueChanged should fire (fired {valueChangedCount} times)");
+        Assert.Equal (Schemes.Error, capturedNewValue);
+        Assert.Equal (Schemes.Error, optionSelector!.Value);
+
+        c.Dispose ();
+    }
+
     [Theory]
     [MemberData (nameof (GetAllDriverNames))]
     public void MenuBar_Not_Active_DoesNotEat_Space (string d)

--- a/Tests/IntegrationTests/FluentTests/MenuBarvTests.cs
+++ b/Tests/IntegrationTests/FluentTests/MenuBarvTests.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using System.Globalization;
 using TerminalGuiFluentTesting;
 using TerminalGuiFluentTestingXunit;
@@ -383,7 +384,7 @@ public class MenuBarTests : TestsAllDrivers
     [Fact]
     public void OptionSelector_In_SubMenu_Click_Sets_Correct_Value ()
     {
-        string d = "ansi";
+        var d = "ansi";
         MenuBar? menuBar = null;
         IApplication? app = null;
         OptionSelector<Schemes>? optionSelector = null;
@@ -433,6 +434,7 @@ public class MenuBarTests : TestsAllDrivers
 
                         optionSelector.ValueChanged += (_, args) =>
                                                        {
+                                                           Logging.Debug ($"OptionSelector ValueChanged event fired with new value: {args.Value}");
                                                            capturedNewValue = args.Value;
                                                            valueChangedCount++;
                                                        };
@@ -447,20 +449,19 @@ public class MenuBarTests : TestsAllDrivers
 
         c = c.Then (_ =>
                     {
-                        errorCheckBox = optionSelector!.SubViews.OfType<CheckBox> ()
-                                                       .FirstOrDefault (cb => (int)cb.Data! == (int)Schemes.Error);
+                        errorCheckBox = optionSelector!.SubViews.OfType<CheckBox> ().FirstOrDefault (cb => (int)cb.Data! == (int)Schemes.Error);
                         Assert.NotNull (errorCheckBox);
-                        System.Drawing.Point pos = errorCheckBox!.FrameToScreen ().Location;
+                        Point pos = errorCheckBox!.FrameToScreen ().Location;
                         errorScreenX = pos.X;
                         errorScreenY = pos.Y;
                     });
 
         c = c.LeftClick (errorScreenX, errorScreenY);
 
-        c = c.ScreenShot ("After clicking Error (full driver sequence)", _out);
+        c.WriteOutLogs (_out);
 
         // Assert — Value should change from Base (0) to Error (4), not to Menu (1)
-        Assert.Equal (Schemes.Error, optionSelector!.Value);
+        Assert.Equal (Schemes.Error, optionSelector?.Value);
 
         c.Dispose ();
     }
@@ -475,7 +476,7 @@ public class MenuBarTests : TestsAllDrivers
     [Fact]
     public void Bar_CommandView_In_Menu_Click_Activates_Correct_Shortcut ()
     {
-        string d = "ansi";
+        var d = "ansi";
         IApplication? app = null;
         MenuBar? menuBar = null;
         var shortcut1ActivatedCount = 0;
@@ -503,17 +504,10 @@ public class MenuBarTests : TestsAllDrivers
                                        menuBar = new MenuBar
                                        {
                                            Menus =
-                                           [
-                                               new MenuBarItem ("_Test",
-                                                                [
-                                                                    new MenuItem
-                                                                    {
-                                                                        Id = "barItem",
-                                                                        HelpText = "Bar with shortcuts",
-                                                                        CommandView = bar
-                                                                    }
-                                                                ])
-                                           ]
+                                               [
+                                                   new MenuBarItem ("_Test",
+                                                                    [new MenuItem { Id = "barItem", HelpText = "Bar with shortcuts", CommandView = bar }])
+                                               ]
                                        };
 
                                        app.TopRunnableView!.Add (menuBar);
@@ -533,7 +527,7 @@ public class MenuBarTests : TestsAllDrivers
 
         c = c.Then (_ =>
                     {
-                        System.Drawing.Point pos = shortcut2!.FrameToScreen ().Location;
+                        Point pos = shortcut2!.FrameToScreen ().Location;
                         screenX = pos.X + 1; // offset into the text area
                         screenY = pos.Y;
                     });
@@ -558,7 +552,7 @@ public class MenuBarTests : TestsAllDrivers
     [Fact]
     public void OptionSelector_In_RootMenu_Space_Sets_Correct_Value ()
     {
-        string d = "ansi";
+        var d = "ansi";
         MenuBar? menuBar = null;
         IApplication? app = null;
         OptionSelector<Schemes>? optionSelector = null;
@@ -576,17 +570,15 @@ public class MenuBarTests : TestsAllDrivers
                                        menuBar = new MenuBar
                                        {
                                            Menus =
-                                           [
-                                               new MenuBarItem ("_Test",
-                                                                [
-                                                                    new MenuItem
-                                                                    {
-                                                                        Id = "selectorItem",
-                                                                        HelpText = "Pick a scheme",
-                                                                        CommandView = optionSelector
-                                                                    }
-                                                                ])
-                                           ]
+                                               [
+                                                   new MenuBarItem ("_Test",
+                                                                    [
+                                                                        new MenuItem
+                                                                            {
+                                                                                Id = "selectorItem", HelpText = "Pick a scheme", CommandView = optionSelector
+                                                                            }
+                                                                    ])
+                                               ]
                                        };
 
                                        app.TopRunnableView!.Add (menuBar);
@@ -619,6 +611,154 @@ public class MenuBarTests : TestsAllDrivers
         c = c.KeyDown (Key.Space);
 
         c = c.ScreenShot ("After Space on Error", _out);
+
+        // Step 5: Assert
+        Assert.True (valueChangedCount >= 1, $"ValueChanged should fire (fired {valueChangedCount} times)");
+        Assert.Equal (Schemes.Error, capturedNewValue);
+        Assert.Equal (Schemes.Error, optionSelector!.Value);
+
+        c.Dispose ();
+    }
+
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     Simpler variant: OptionSelector directly in the root Menu (no SubMenu nesting).
+    ///     Isolates whether the bug is SubMenu-specific or general to PopoverMenu.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_Menu_Click_Sets_Correct_Value ()
+    {
+        var d = "ansi";
+        Menu? menu = null;
+        IApplication? app = null;
+        OptionSelector<Schemes>? optionSelector = null;
+        Schemes? capturedNewValue = null;
+        var valueChangedCount = 0;
+
+        // Step 1: Build a simple MenuBar with an OptionSelector directly in the root Menu
+        TestContext c = With.A<Window> (80, 30, d, _out)
+                            .Then (a =>
+                                   {
+                                       app = a;
+
+                                       optionSelector = new OptionSelector<Schemes> { Title = "Scheme", CanFocus = true };
+
+                                       menu = new Menu ([new MenuItem { Id = "selectorItem", HelpText = "Pick a scheme", CommandView = optionSelector }]);
+
+                                       app.TopRunnableView!.Add (menu);
+
+                                       optionSelector.ValueChanged += (_, args) =>
+                                                                      {
+                                                                          Logging.Debug ($"OptionSelector ValueChanged event fired with new value: {
+                                                                              args.Value
+                                                                          }");
+                                                                          capturedNewValue = args.Value;
+                                                                          valueChangedCount++;
+                                                                      };
+                                   });
+
+        c = c.WaitIteration ();
+
+        // Click directly on the Error checkbox WITHOUT keyboard navigation first.
+        CheckBox? errorCheckBox = null;
+        var errorScreenX = 0;
+        var errorScreenY = 0;
+
+        c = c.Then (_ =>
+                    {
+                        errorCheckBox = optionSelector!.SubViews.OfType<CheckBox> ().FirstOrDefault (cb => (int)cb.Data! == (int)Schemes.Error);
+                        Assert.NotNull (errorCheckBox);
+                        Point pos = errorCheckBox!.FrameToScreen ().Location;
+                        errorScreenX = pos.X;
+                        errorScreenY = pos.Y;
+                    });
+
+        c = c.LeftClick (errorScreenX, errorScreenY);
+
+        c.WriteOutLogs (_out);
+
+        // Step 5: Assert
+        Assert.True (valueChangedCount >= 1, $"ValueChanged should fire (fired {valueChangedCount} times)");
+        Assert.Equal (Schemes.Error, capturedNewValue);
+        Assert.Equal (Schemes.Error, optionSelector!.Value);
+
+        c.Dispose ();
+    }
+
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     Simpler variant: OptionSelector directly in the root Menu (no SubMenu nesting).
+    ///     Isolates whether the bug is SubMenu-specific or general to PopoverMenu.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_RootMenu_Click_Sets_Correct_Value ()
+    {
+        var d = "ansi";
+        MenuBar? menuBar = null;
+        IApplication? app = null;
+        OptionSelector<Schemes>? optionSelector = null;
+        Schemes? capturedNewValue = null;
+        var valueChangedCount = 0;
+
+        // Step 1: Build a simple MenuBar with an OptionSelector directly in the root Menu
+        TestContext c = With.A<Window> (80, 30, d, _out)
+                            .Then (a =>
+                                   {
+                                       app = a;
+
+                                       optionSelector = new OptionSelector<Schemes> { Title = "Scheme", CanFocus = true };
+
+                                       menuBar = new MenuBar
+                                       {
+                                           Menus =
+                                               [
+                                                   new MenuBarItem ("_Test",
+                                                                    [
+                                                                        new MenuItem
+                                                                            {
+                                                                                Id = "selectorItem", HelpText = "Pick a scheme", CommandView = optionSelector
+                                                                            }
+                                                                    ])
+                                               ]
+                                       };
+
+                                       app.TopRunnableView!.Add (menuBar);
+
+                                       optionSelector.ValueChanged += (_, args) =>
+                                                                      {
+                                                                          Logging.Debug ($"OptionSelector ValueChanged event fired with new value: {
+                                                                              args.Value
+                                                                          }");
+                                                                          capturedNewValue = args.Value;
+                                                                          valueChangedCount++;
+                                                                      };
+                                   });
+
+        c = c.WaitIteration ();
+
+        // Step 2: Open the Test menu
+        c = c.KeyDown (MenuBar.DefaultKey);
+        Assert.True (menuBar!.IsOpen (), "Menu should be open after F9");
+
+        // Step 6: Click directly on the Error checkbox WITHOUT keyboard navigation first.
+        // This simulates the real user scenario where the user opens the menu and clicks
+        // directly on a checkbox without using arrow keys.
+        CheckBox? errorCheckBox = null;
+        var errorScreenX = 0;
+        var errorScreenY = 0;
+
+        c = c.Then (_ =>
+                    {
+                        errorCheckBox = optionSelector!.SubViews.OfType<CheckBox> ().FirstOrDefault (cb => (int)cb.Data! == (int)Schemes.Error);
+                        Assert.NotNull (errorCheckBox);
+                        Point pos = errorCheckBox!.FrameToScreen ().Location;
+                        errorScreenX = pos.X;
+                        errorScreenY = pos.Y;
+                    });
+
+        c = c.LeftClick (errorScreenX, errorScreenY);
+
+        c.WriteOutLogs (_out);
 
         // Step 5: Assert
         Assert.True (valueChangedCount >= 1, $"ValueChanged should fire (fired {valueChangedCount} times)");

--- a/Tests/IntegrationTests/FluentTests/PopverMenuTests.cs
+++ b/Tests/IntegrationTests/FluentTests/PopverMenuTests.cs
@@ -23,27 +23,27 @@ public class PopoverMenuTests : TestsAllDrivers
     public void EnableForDesign_CreatesMenuItems (string d)
     {
         using TestContext c = With.A<Window> (80, 25, d)
-                                     .Then ((app) =>
-                                            {
-                                                PopoverMenu popoverMenu = new ();
-                                                app.TopRunnableView!.Add (popoverMenu);
+                                  .Then (app =>
+                                         {
+                                             PopoverMenu popoverMenu = new ();
+                                             app.TopRunnableView!.Add (popoverMenu);
 
-                                                // Call EnableForDesign
-                                                View top = app.TopRunnableView;
-                                                bool result = popoverMenu.EnableForDesign (ref top);
+                                             // Call EnableForDesign
+                                             View top = app.TopRunnableView;
+                                             bool result = popoverMenu.EnableForDesign (ref top);
 
-                                                // Should return true
-                                                Assert.True (result);
+                                             // Should return true
+                                             Assert.True (result);
 
-                                                // Should have created menu items
-                                                Assert.NotNull (popoverMenu.Root);
-                                                Assert.Equal (7, popoverMenu.Root.SubViews.Count);
+                                             // Should have created menu items
+                                             Assert.NotNull (popoverMenu.Root);
+                                             Assert.Equal (7, popoverMenu.Root.SubViews.Count);
 
-                                                // Should have Cut menu item
-                                                View? cutMenuItem = popoverMenu.GetMenuItemsOfAllSubMenus ().FirstOrDefault (v => v?.Title == "Cu_t");
+                                             // Should have Cut menu item
+                                             View? cutMenuItem = popoverMenu.GetMenuItemsOfAllSubMenus ().FirstOrDefault (v => v?.Title == "Cu_t");
 
-                                                Assert.NotNull (cutMenuItem);
-                                            });
+                                             Assert.NotNull (cutMenuItem);
+                                         });
     }
 
     private static readonly object o = new ();
@@ -55,43 +55,41 @@ public class PopoverMenuTests : TestsAllDrivers
         lock (o)
         {
             IApplication? app = null;
+
             using TestContext c = With.A<Window> (50, 20, d)
-                                         .Then ((a) =>
-                                                {
-                                                    app = a;
-                                                    PopoverMenu popoverMenu = new ()
-                                                    {
-                                                        App = app
-                                                    };
+                                      .Then (a =>
+                                             {
+                                                 app = a;
+                                                 PopoverMenu popoverMenu = new () { App = app };
 
-                                                    // Call EnableForDesign
-                                                    View top = app.TopRunnableView!;
-                                                    popoverMenu.EnableForDesign (ref top);
+                                                 // Call EnableForDesign
+                                                 View top = app.TopRunnableView!;
+                                                 popoverMenu.EnableForDesign (ref top);
 
-                                                    var view = new View
-                                                    {
-                                                        CanFocus = true,
-                                                        Height = Dim.Auto (),
-                                                        Width = Dim.Auto (),
-                                                        Id = "focusableView",
-                                                        Text = "View"
-                                                    };
-                                                    app.TopRunnableView!.Add (view);
+                                                 var view = new View
+                                                 {
+                                                     CanFocus = true,
+                                                     Height = Dim.Auto (),
+                                                     Width = Dim.Auto (),
+                                                     Id = "focusableView",
+                                                     Text = "View"
+                                                 };
+                                                 app.TopRunnableView!.Add (view);
 
-                                                    // EnableForDesign sets to true; undo that
-                                                    popoverMenu.Visible = false;
+                                                 // EnableForDesign sets to true; undo that
+                                                 popoverMenu.Visible = false;
 
-                                                    app?.Popover!.Register (popoverMenu);
+                                                 app?.Popover!.Register (popoverMenu);
 
-                                                    view.SetFocus ();
-                                                })
-                                         .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
-                                         .AssertIsNotType<MenuItem> (app?.Navigation!.GetFocused ())
-                                         .ScreenShot ("PopoverMenu initial state", _out)
-                                         .Then ((_) => app?.Popover!.Show (app?.Popover.Popovers.First ()))
-                                         .ScreenShot ("After Show", _out)
-                                         .AssertTrue (app?.Popover?.GetActivePopover () is PopoverMenu)
-                                         .AssertEqual ("Cu_t", app?.Navigation!.GetFocused ()!.Title);
+                                                 view.SetFocus ();
+                                             })
+                                      .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
+                                      .AssertIsNotType<MenuItem> (app?.Navigation!.GetFocused ())
+                                      .ScreenShot ("PopoverMenu initial state", _out)
+                                      .Then (_ => app?.Popover!.Show (app?.Popover.Popovers.First ()))
+                                      .ScreenShot ("After Show", _out)
+                                      .AssertTrue (app?.Popover?.GetActivePopover () is PopoverMenu)
+                                      .AssertEqual ("Cu_t", app?.Navigation!.GetFocused ()!.Title);
         }
     }
 
@@ -100,46 +98,44 @@ public class PopoverMenuTests : TestsAllDrivers
     public void QuitKey_Hides (string d)
     {
         IApplication? app = null;
+
         using TestContext c = With.A<Window> (50, 20, d)
-                                     .Then ((a) =>
-                                            {
-                                                app = a;
-                                                PopoverMenu popoverMenu = new ()
-                                                {
-                                                    App = app
-                                                };
+                                  .Then (a =>
+                                         {
+                                             app = a;
+                                             PopoverMenu popoverMenu = new () { App = app };
 
-                                                // Call EnableForDesign
-                                                View top = app.TopRunnableView!;
-                                                bool result = popoverMenu.EnableForDesign (ref top);
+                                             // Call EnableForDesign
+                                             View top = app.TopRunnableView!;
+                                             bool result = popoverMenu.EnableForDesign (ref top);
 
-                                                var view = new View
-                                                {
-                                                    CanFocus = true,
-                                                    Height = Dim.Auto (),
-                                                    Width = Dim.Auto (),
-                                                    Id = "focusableView",
-                                                    Text = "View"
-                                                };
-                                                app.TopRunnableView!.Add (view);
+                                             var view = new View
+                                             {
+                                                 CanFocus = true,
+                                                 Height = Dim.Auto (),
+                                                 Width = Dim.Auto (),
+                                                 Id = "focusableView",
+                                                 Text = "View"
+                                             };
+                                             app.TopRunnableView!.Add (view);
 
-                                                // EnableForDesign sets to true; undo that
-                                                popoverMenu.Visible = false;
+                                             // EnableForDesign sets to true; undo that
+                                             popoverMenu.Visible = false;
 
-                                                app?.Popover!.Register (popoverMenu);
+                                             app?.Popover!.Register (popoverMenu);
 
-                                                view.SetFocus ();
-                                            })
-                                     .ScreenShot ("PopoverMenu initial state", _out)
-                                     .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
-                                     .Then ((_) => app?.Popover!.Show (app?.Popover.Popovers.First ()))
-                                     .ScreenShot ("After Show", _out)
-                                     .AssertTrue (app?.Popover?.GetActivePopover () is PopoverMenu)
-                                     .KeyDown (Application.QuitKey)
-                                     .ScreenShot ($"After {Application.QuitKey}", _out)
-                                     .AssertFalse (app?.Popover!.Popovers.Cast<PopoverMenu> ().FirstOrDefault ()!.Visible)
-                                     .AssertNull (app?.Popover!.GetActivePopover ())
-                                     .AssertTrue (app?.TopRunnable!.IsRunning);
+                                             view.SetFocus ();
+                                         })
+                                  .ScreenShot ("PopoverMenu initial state", _out)
+                                  .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
+                                  .Then (_ => app?.Popover!.Show (app?.Popover.Popovers.First ()))
+                                  .ScreenShot ("After Show", _out)
+                                  .AssertTrue (app?.Popover?.GetActivePopover () is PopoverMenu)
+                                  .KeyDown (Application.QuitKey)
+                                  .ScreenShot ($"After {Application.QuitKey}", _out)
+                                  .AssertFalse (app?.Popover!.Popovers.Cast<PopoverMenu> ().FirstOrDefault ()!.Visible)
+                                  .AssertNull (app?.Popover!.GetActivePopover ())
+                                  .AssertTrue (app?.TopRunnable!.IsRunning);
     }
 
     [Theory]
@@ -147,47 +143,45 @@ public class PopoverMenuTests : TestsAllDrivers
     public void QuitKey_Restores_Focus_Correctly (string d)
     {
         IApplication? app = null;
+
         using TestContext c = With.A<Window> (50, 20, d)
-                                     .Then ((a) =>
-                                            {
-                                                app = a;
-                                                PopoverMenu popoverMenu = new ()
-                                                {
-                                                    App = app
-                                                };
+                                  .Then (a =>
+                                         {
+                                             app = a;
+                                             PopoverMenu popoverMenu = new () { App = app };
 
-                                                // Call EnableForDesign
-                                                View top = app.TopRunnableView!;
-                                                bool result = popoverMenu.EnableForDesign (ref top);
+                                             // Call EnableForDesign
+                                             View top = app.TopRunnableView!;
+                                             bool result = popoverMenu.EnableForDesign (ref top);
 
-                                                var view = new View
-                                                {
-                                                    CanFocus = true,
-                                                    Height = Dim.Auto (),
-                                                    Width = Dim.Auto (),
-                                                    Id = "focusableView",
-                                                    Text = "View"
-                                                };
-                                                app.TopRunnableView!.Add (view);
+                                             var view = new View
+                                             {
+                                                 CanFocus = true,
+                                                 Height = Dim.Auto (),
+                                                 Width = Dim.Auto (),
+                                                 Id = "focusableView",
+                                                 Text = "View"
+                                             };
+                                             app.TopRunnableView!.Add (view);
 
-                                                // EnableForDesign sets to true; undo that
-                                                popoverMenu.Visible = false;
+                                             // EnableForDesign sets to true; undo that
+                                             popoverMenu.Visible = false;
 
-                                                app?.Popover!.Register (popoverMenu);
+                                             app?.Popover!.Register (popoverMenu);
 
-                                                view.SetFocus ();
-                                            })
-                                     .ScreenShot ("PopoverMenu initial state", _out)
-                                     .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
-                                     .AssertIsNotType<MenuItem> (app?.Navigation!.GetFocused ())
-                                     .Then ((_) => app?.Popover!.Show (app?.Popover.Popovers.First ()))
-                                     .ScreenShot ("After Show", _out)
-                                     .AssertTrue (app?.Popover?.GetActivePopover () is PopoverMenu)
-                                     .AssertIsType<MenuItem> (app?.Navigation!.GetFocused ())
-                                     .KeyDown (Application.QuitKey)
-                                     .ScreenShot ($"After {Application.QuitKey}", _out)
-                                     .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
-                                     .AssertIsNotType<MenuItem> (app?.Navigation!.GetFocused ());
+                                             view.SetFocus ();
+                                         })
+                                  .ScreenShot ("PopoverMenu initial state", _out)
+                                  .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
+                                  .AssertIsNotType<MenuItem> (app?.Navigation!.GetFocused ())
+                                  .Then (_ => app?.Popover!.Show (app?.Popover.Popovers.First ()))
+                                  .ScreenShot ("After Show", _out)
+                                  .AssertTrue (app?.Popover?.GetActivePopover () is PopoverMenu)
+                                  .AssertIsType<MenuItem> (app?.Navigation!.GetFocused ())
+                                  .KeyDown (Application.QuitKey)
+                                  .ScreenShot ($"After {Application.QuitKey}", _out)
+                                  .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
+                                  .AssertIsNotType<MenuItem> (app?.Navigation!.GetFocused ());
     }
 
     [Theory]
@@ -197,45 +191,42 @@ public class PopoverMenuTests : TestsAllDrivers
         IApplication? app = null;
 
         using TestContext c = With.A<Window> (50, 20, d)
-                                     .Then ((a) =>
-                                            {
-                                                app = a;
-                                                PopoverMenu popoverMenu = new ()
-                                                {
-                                                    App = app
-                                                };
+                                  .Then (a =>
+                                         {
+                                             app = a;
+                                             PopoverMenu popoverMenu = new () { App = app };
 
-                                                // Call EnableForDesign
-                                                View top = app.TopRunnableView!;
-                                                bool result = popoverMenu.EnableForDesign (ref top);
+                                             // Call EnableForDesign
+                                             View top = app.TopRunnableView!;
+                                             bool result = popoverMenu.EnableForDesign (ref top);
 
-                                                var view = new View
-                                                {
-                                                    CanFocus = true,
-                                                    Height = Dim.Auto (),
-                                                    Width = Dim.Auto (),
-                                                    Id = "focusableView",
-                                                    Text = "View"
-                                                };
-                                                app.TopRunnableView!.Add (view);
+                                             var view = new View
+                                             {
+                                                 CanFocus = true,
+                                                 Height = Dim.Auto (),
+                                                 Width = Dim.Auto (),
+                                                 Id = "focusableView",
+                                                 Text = "View"
+                                             };
+                                             app.TopRunnableView!.Add (view);
 
-                                                // EnableForDesign sets to true; undo that
-                                                popoverMenu.Visible = false;
+                                             // EnableForDesign sets to true; undo that
+                                             popoverMenu.Visible = false;
 
-                                                app?.Popover!.Register (popoverMenu);
+                                             app?.Popover!.Register (popoverMenu);
 
-                                                view.SetFocus ();
-                                            })
-                                     .AssertIsNotType<MenuItem> (app?.Navigation!.GetFocused ())
-                                     .ScreenShot ("PopoverMenu initial state", _out)
-                                     .Then ((_) => app?.Popover!.Show (app?.Popover.Popovers.First ()))
-                                     .ScreenShot ("PopoverMenu after Show", _out)
-                                     .AssertEqual ("Cu_t", app?.Navigation!.GetFocused ()!.Title)
-                                     .AssertTrue (app?.TopRunnable!.IsRunning)
-                                     .KeyDown (Application.QuitKey)
-                                     .ScreenShot ($"After {Application.QuitKey}", _out)
-                                     .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
-                                     .AssertTrue (app?.TopRunnable!.IsRunning);
+                                             view.SetFocus ();
+                                         })
+                                  .AssertIsNotType<MenuItem> (app?.Navigation!.GetFocused ())
+                                  .ScreenShot ("PopoverMenu initial state", _out)
+                                  .Then (_ => app?.Popover!.Show (app?.Popover.Popovers.First ()))
+                                  .ScreenShot ("PopoverMenu after Show", _out)
+                                  .AssertEqual ("Cu_t", app?.Navigation!.GetFocused ()!.Title)
+                                  .AssertTrue (app?.TopRunnable!.IsRunning)
+                                  .KeyDown (Application.QuitKey)
+                                  .ScreenShot ($"After {Application.QuitKey}", _out)
+                                  .AssertFalse (app?.Popover?.GetActivePopover () is PopoverMenu)
+                                  .AssertTrue (app?.TopRunnable!.IsRunning);
     }
 
     [Theory]
@@ -244,11 +235,7 @@ public class PopoverMenuTests : TestsAllDrivers
     {
         var spaceKeyDownCount = 0;
 
-        var testView = new View
-        {
-            CanFocus = true,
-            Id = "testView"
-        };
+        var testView = new View { CanFocus = true, Id = "testView" };
 
         testView.KeyDown += (sender, key) =>
                             {
@@ -259,22 +246,20 @@ public class PopoverMenuTests : TestsAllDrivers
                             };
 
         IApplication? app = null;
+
         using TestContext c = With.A<Window> (50, 20, d)
-                                     .Then ((a) =>
-                                            {
-                                                app = a;
-                                                PopoverMenu popoverMenu = new ()
-                                                {
-                                                    App = app
-                                                };
-                                                View top = app.TopRunnableView!;
-                                                popoverMenu.EnableForDesign (ref top);
-                                                app?.Popover!.Register (popoverMenu);
-                                            })
-                                     .Add (testView)
-                                     .Focus (testView)
-                                     .KeyDown (Key.Space)
-                                     .AssertEqual (1, spaceKeyDownCount);
+                                  .Then (a =>
+                                         {
+                                             app = a;
+                                             PopoverMenu popoverMenu = new () { App = app };
+                                             View top = app.TopRunnableView!;
+                                             popoverMenu.EnableForDesign (ref top);
+                                             app?.Popover!.Register (popoverMenu);
+                                         })
+                                  .Add (testView)
+                                  .Focus (testView)
+                                  .KeyDown (Key.Space)
+                                  .AssertEqual (1, spaceKeyDownCount);
     }
 
     [Theory]
@@ -283,11 +268,7 @@ public class PopoverMenuTests : TestsAllDrivers
     {
         var enterKeyDownCount = 0;
 
-        var testView = new View
-        {
-            CanFocus = true,
-            Id = "testView"
-        };
+        var testView = new View { CanFocus = true, Id = "testView" };
 
         testView.KeyDown += (sender, key) =>
                             {
@@ -300,21 +281,18 @@ public class PopoverMenuTests : TestsAllDrivers
         IApplication? app = null;
 
         using TestContext c = With.A<Window> (50, 20, d)
-                                     .Then ((a) =>
-                                            {
-                                                app = a;
-                                                PopoverMenu popoverMenu = new ()
-                                                {
-                                                    App = app
-                                                };
-                                                View top = app.TopRunnableView!;
-                                                popoverMenu.EnableForDesign (ref top);
-                                                app?.Popover!.Register (popoverMenu);
-                                            })
-                                     .Add (testView)
-                                     .Focus (testView)
-                                     .KeyDown (Key.Enter)
-                                     .AssertEqual (1, enterKeyDownCount);
+                                  .Then (a =>
+                                         {
+                                             app = a;
+                                             PopoverMenu popoverMenu = new () { App = app };
+                                             View top = app.TopRunnableView!;
+                                             popoverMenu.EnableForDesign (ref top);
+                                             app?.Popover!.Register (popoverMenu);
+                                         })
+                                  .Add (testView)
+                                  .Focus (testView)
+                                  .KeyDown (Key.Enter)
+                                  .AssertEqual (1, enterKeyDownCount);
     }
 
     [Theory]
@@ -323,11 +301,7 @@ public class PopoverMenuTests : TestsAllDrivers
     {
         var quitKeyDownCount = 0;
 
-        var testView = new View
-        {
-            CanFocus = true,
-            Id = "testView"
-        };
+        var testView = new View { CanFocus = true, Id = "testView" };
 
         testView.KeyDown += (sender, key) =>
                             {
@@ -338,21 +312,19 @@ public class PopoverMenuTests : TestsAllDrivers
                             };
 
         IApplication? app = null;
+
         using TestContext c = With.A<Window> (50, 20, d)
-                                     .Then ((a) =>
-                                            {
-                                                app = a;
-                                                PopoverMenu popoverMenu = new ()
-                                                {
-                                                    App = app
-                                                };
-                                                View top = app.TopRunnableView!;
-                                                popoverMenu.EnableForDesign (ref top);
-                                                app?.Popover!.Register (popoverMenu);
-                                            })
-                                     .Add (testView)
-                                     .KeyDown (Application.QuitKey)
-                                     .AssertEqual (1, quitKeyDownCount);
+                                  .Then (a =>
+                                         {
+                                             app = a;
+                                             PopoverMenu popoverMenu = new () { App = app };
+                                             View top = app.TopRunnableView!;
+                                             popoverMenu.EnableForDesign (ref top);
+                                             app?.Popover!.Register (popoverMenu);
+                                         })
+                                  .Add (testView)
+                                  .KeyDown (Application.QuitKey)
+                                  .AssertEqual (1, quitKeyDownCount);
     }
 
     [Theory]
@@ -364,27 +336,28 @@ public class PopoverMenuTests : TestsAllDrivers
         MenuItem [] menuItems = [new ("_New File", string.Empty, () => { clicked = true; })];
 
         IApplication? app = null;
-        using TestContext c = With.A<Window> (40, 10, d,  _out)
-                                     .Then ((a) => app = a)
-                                     .WithContextMenu (new (menuItems) { App = app })
-                                     .ScreenShot ("Before open menu", _out)
 
-                                     // Click in main area inside border
-                                     .RightClick (1, 1)
-                                     .Then ((_) =>
-                                            {
-                                                // Test depends on menu having a border
-                                                IPopover? popover = app?.Popover!.GetActivePopover ();
-                                                Assert.NotNull (popover);
-                                                var popoverMenu = popover as PopoverMenu;
-                                                popoverMenu!.Root!.BorderStyle = LineStyle.Single;
-                                            })
-                                     .ScreenShot ("After open menu", _out)
-                                     .LeftClick (2, 2)
-                                     .AssertTrue(clicked);
+        using TestContext c = With.A<Window> (40, 10, d, _out)
+                                  .Then (a => app = a)
+                                  .WithContextMenu (new PopoverMenu (menuItems) { App = app })
+                                  .ScreenShot ("Before open menu", _out)
+
+                                  // Click in main area inside border
+                                  .RightClick (1, 1)
+                                  .Then (_ =>
+                                         {
+                                             // Test depends on menu having a border
+                                             IPopover? popover = app?.Popover!.GetActivePopover ();
+                                             Assert.NotNull (popover);
+                                             var popoverMenu = popover as PopoverMenu;
+                                             popoverMenu!.Root!.BorderStyle = LineStyle.Single;
+                                         })
+                                  .ScreenShot ("After open menu", _out)
+                                  .LeftClick (2, 2)
+                                  .AssertTrue (clicked);
     }
 
-    [Theory (Skip = "#4620 - Requires Phase 5: Activate event bridging across PopoverMenu boundary")]
+    [Theory]
     [MemberData (nameof (GetAllDriverNames))]
     public void ContextMenu_OpenSubmenu (string d)
     {
@@ -395,19 +368,17 @@ public class PopoverMenuTests : TestsAllDrivers
             new ("One", "", null),
             new ("Two", "", null),
             new ("Three", "", null),
-            new (
-                 "Four",
+            new ("Four",
                  "",
-                 new (
-                      [
-                          new ("SubMenu1", "", null),
-                          new ("SubMenu2", "", () => clicked = true),
-                          new ("SubMenu3", "", null),
-                          new ("SubMenu4", "", null),
-                          new ("SubMenu5", "", null),
-                          new ("SubMenu6", "", null),
-                          new ("SubMenu7", "", null)
-                      ])),
+                 new Menu ([
+                               new MenuItem ("SubMenu1", "", null),
+                               new MenuItem ("SubMenu2", "", () => clicked = true),
+                               new MenuItem ("SubMenu3", "", null),
+                               new MenuItem ("SubMenu4", "", null),
+                               new MenuItem ("SubMenu5", "", null),
+                               new MenuItem ("SubMenu6", "", null),
+                               new MenuItem ("SubMenu7", "", null)
+                           ])),
             new ("Five", "", null),
             new ("Six", "", null)
         ];
@@ -415,21 +386,21 @@ public class PopoverMenuTests : TestsAllDrivers
         IApplication? app = null;
 
         using TestContext c = With.A<Window> (40, 10, d)
-                                     .Then ((a) => app = a)
-                                     .WithContextMenu (new (menuItems) { App = app })
-                                     .ScreenShot ("Before open menu", _out)
+                                  .Then (a => app = a)
+                                  .WithContextMenu (new PopoverMenu (menuItems) { App = app })
+                                  .ScreenShot ("Before open menu", _out)
 
-                                     // Click in main area inside border
-                                     .RightClick (1, 1)
-                                     .ScreenShot ("After open menu", _out)
-                                     .KeyDown (Key.CursorDown)
-                                     .KeyDown (Key.CursorDown)
-                                     .KeyDown (Key.CursorDown)
-                                     .KeyDown (Key.CursorRight)
-                                     .ScreenShot ("After open submenu", _out)
-                                     .KeyDown (Key.CursorDown)
-                                     .KeyDown (Key.Enter)
-                                     .ScreenShot ("Menu should be closed after selecting", _out);
+                                  // Click in main area inside border
+                                  .RightClick (1, 1)
+                                  .ScreenShot ("After open menu", _out)
+                                  .KeyDown (Key.CursorDown)
+                                  .KeyDown (Key.CursorDown)
+                                  .KeyDown (Key.CursorDown)
+                                  .KeyDown (Key.CursorRight)
+                                  .ScreenShot ("After open submenu", _out)
+                                  .KeyDown (Key.CursorDown)
+                                  .KeyDown (Key.Enter)
+                                  .ScreenShot ("Menu should be closed after selecting", _out);
         Assert.True (clicked);
     }
 }

--- a/Tests/UnitTestsParallelizable/Input/InputBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/InputBindingTests.cs
@@ -227,13 +227,17 @@ public class CommandBindingTests
     #region Record Equality Tests
 
     [Fact ]
+    // Claude - Opus 4.6
     public void RecordEquality_SameValues_AreEqual ()
     {
         Command [] commands = [Command.Activate];
         View source = new () { Id = "source" };
+        WeakReference<View> weakSource = new (source);
 
-        CommandBinding binding1 = new (commands, source, "data");
-        CommandBinding binding2 = new (commands, source, "data");
+        // Share the same WeakReference instance — two distinct WeakReferences to the same target
+        // are not reference-equal, so record equality requires the same instance.
+        CommandBinding binding1 = new () { Commands = commands, Source = weakSource, Data = "data" };
+        CommandBinding binding2 = new () { Commands = commands, Source = weakSource, Data = "data" };
 
         Assert.Equal (binding1, binding2);
     }

--- a/Tests/UnitTestsParallelizable/Input/InputBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/InputBindingTests.cs
@@ -31,7 +31,9 @@ public class CommandBindingTests
         CommandBinding binding = new (commands, source);
 
         Assert.Equal (commands, binding.Commands);
-        Assert.Equal (source, binding.Source);
+        View? sv = null;
+        Assert.True (binding.Source?.TryGetTarget (out sv) == true);
+        Assert.Equal (source, sv);
         Assert.Null (binding.Data);
     }
 
@@ -45,7 +47,9 @@ public class CommandBindingTests
         CommandBinding binding = new (commands, source, data);
 
         Assert.Equal (commands, binding.Commands);
-        Assert.Equal (source, binding.Source);
+        View? sv = null;
+        Assert.True (binding.Source?.TryGetTarget (out sv) == true);
+        Assert.Equal (source, sv);
         Assert.Equal ("test data", binding.Data);
     }
 
@@ -93,12 +97,12 @@ public class CommandBindingTests
     [Fact ]
     public void ImplementsICommandBinding ()
     {
-        CommandBinding binding = new ([Command.Activate]) { Source = new View { Id = "test" }, Data = "data" };
+        CommandBinding binding = new ([Command.Activate]) { Source = new WeakReference<View> (new View { Id = "test" }), Data = "data" };
 
         ICommandBinding iBinding = binding;
 
         Assert.Equal (binding.Commands, iBinding.Commands);
-        Assert.Equal (binding.Source, iBinding.Source);
+        Assert.Same (binding.Source, iBinding.Source);
         Assert.Equal (binding.Data, iBinding.Data);
     }
 
@@ -109,7 +113,9 @@ public class CommandBindingTests
 
         Assert.Single (binding.Commands);
         Assert.Equal (Command.Accept, binding.Commands [0]);
-        Assert.Equal ("polymorphic", binding.Source?.Id);
+        View? sv = null;
+        Assert.True (binding.Source?.TryGetTarget (out sv) == true);
+        Assert.Equal ("polymorphic", sv?.Id);
     }
 
     #endregion
@@ -206,7 +212,9 @@ public class CommandBindingTests
         // Can pattern match the binding from the interface
         if (ctx.Binding is CommandBinding ib)
         {
-            Assert.Equal ("test", ib.Source?.Id);
+            View? sv = null;
+            Assert.True (ib.Source?.TryGetTarget (out sv) == true);
+            Assert.Equal ("test", sv?.Id);
         }
         else
         {

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/KeyBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/KeyBindingTests.cs
@@ -134,11 +134,13 @@ public class KeyBindingTests
         View sourceView = new () { Id = "sourceView" };
         View targetView = new () { Id = "targetView" };
 
-        KeyBinding binding = new ([Command.HotKey]) { Source = sourceView, Target = targetView };
+        KeyBinding binding = new ([Command.HotKey]) { Source = new WeakReference<View> (sourceView), Target = targetView };
 
-        Assert.Equal (sourceView, binding.Source);
+        View? sv = null;
+        Assert.True (binding.Source?.TryGetTarget (out sv) == true);
+        Assert.Equal (sourceView, sv);
         Assert.Equal (targetView, binding.Target);
-        Assert.NotEqual (binding.Source, binding.Target);
+        Assert.NotSame (sv, binding.Target);
     }
 
     [Fact]
@@ -146,11 +148,13 @@ public class KeyBindingTests
     {
         View view = new () { Id = "sameView" };
 
-        KeyBinding binding = new ([Command.Activate]) { Source = view, Target = view };
+        KeyBinding binding = new ([Command.Activate]) { Source = new WeakReference<View> (view), Target = view };
 
-        Assert.Equal (view, binding.Source);
+        View? sv = null;
+        Assert.True (binding.Source?.TryGetTarget (out sv) == true);
+        Assert.Equal (view, sv);
         Assert.Equal (view, binding.Target);
-        Assert.Same (binding.Source, binding.Target);
+        Assert.Same (sv, binding.Target);
     }
 
     #endregion
@@ -237,13 +241,14 @@ public class KeyBindingTests
     [Fact]
     public void PatternMatching_Key_Works ()
     {
-        KeyBinding binding = new ([Command.Activate]) { Key = Key.F5, Source = new View { Id = "sourceView" }, Target = new View { Id = "targetView" } };
+        KeyBinding binding = new ([Command.Activate]) { Key = Key.F5, Source = new WeakReference<View> (new View { Id = "sourceView" }), Target = new View { Id = "targetView" } };
 
         // Pattern matching on Key property
         if (binding is { Key: { } key, Source: { } source, Target: { } target })
         {
             Assert.Equal (Key.F5, key);
-            Assert.Equal ("sourceView", source.Id);
+            Assert.True (source.TryGetTarget (out View? sv));
+            Assert.Equal ("sourceView", sv?.Id);
             Assert.Equal ("targetView", target.Id);
         }
         else

--- a/Tests/UnitTestsParallelizable/Input/Mouse/MouseBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Mouse/MouseBindingTests.cs
@@ -159,13 +159,14 @@ public class MouseBindingTests
     [Fact]
     public void PatternMatching_MouseEvent_Works ()
     {
-        MouseBinding binding = new ([Command.Activate], MouseFlags.LeftButtonClicked) { Source = new View { Id = "sourceView" } };
+        MouseBinding binding = new ([Command.Activate], MouseFlags.LeftButtonClicked) { Source = new WeakReference<View> (new View { Id = "sourceView" }) };
 
         // Pattern matching on MouseEvent property
         if (binding is { MouseEvent: { } mouseEvent, Source: { } source })
         {
             Assert.Equal (MouseFlags.LeftButtonClicked, mouseEvent.Flags);
-            Assert.Equal ("sourceView", source.Id);
+            Assert.True (source.TryGetTarget (out View? sv));
+            Assert.Equal ("sourceView", sv?.Id);
         }
         else
         {

--- a/Tests/UnitTestsParallelizable/ViewBase/CommandBubblingTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/CommandBubblingTests.cs
@@ -184,7 +184,7 @@ public class CommandBubblingTests
         menuBar.Layout ();
 
         // Act: Invoke Command.Activate on the CheckBox (simulating user pressing Space)
-        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = checkBox };
+        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = new WeakReference<View> (checkBox) };
         CommandContext ctx = new () { Command = Command.Activate, Source = new WeakReference<View> (checkBox), Binding = keyBinding };
 
         checkBox.InvokeCommand (Command.Activate, ctx);
@@ -237,7 +237,7 @@ public class CommandBubblingTests
         menuBar.Layout ();
 
         // Act: Invoke Command.Accept on the CheckBox (simulating double-click)
-        MouseBinding mouseBinding = new ([Command.Accept], MouseFlags.LeftButtonDoubleClicked) { Source = checkBox };
+        MouseBinding mouseBinding = new ([Command.Accept], MouseFlags.LeftButtonDoubleClicked) { Source = new WeakReference<View> (checkBox) };
         CommandContext ctx = new () { Command = Command.Accept, Source = new WeakReference<View> (checkBox), Binding = mouseBinding };
 
         checkBox.InvokeCommand (Command.Accept, ctx);
@@ -290,7 +290,7 @@ public class CommandBubblingTests
         menuBar.Layout ();
 
         // Act
-        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = checkBox };
+        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = new WeakReference<View> (checkBox) };
         CommandContext ctx = new () { Command = Command.Activate, Source = new WeakReference<View> (checkBox), Binding = keyBinding };
 
         checkBox.InvokeCommand (Command.Activate, ctx);
@@ -343,7 +343,7 @@ public class CommandBubblingTests
         menuBar.Layout ();
 
         // Create a distinctive binding we can verify
-        KeyBinding originalBinding = new ([Command.Activate]) { Key = Key.F5, Source = checkBox, Data = "test-data-marker" };
+        KeyBinding originalBinding = new ([Command.Activate]) { Key = Key.F5, Source = new WeakReference<View> (checkBox), Data = "test-data-marker" };
         CommandContext ctx = new () { Command = Command.Activate, Source = new WeakReference<View> (checkBox), Binding = originalBinding };
 
         // Act
@@ -416,7 +416,7 @@ public class CommandBubblingTests
         menuBar.Layout ();
 
         // Act
-        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = checkBox };
+        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = new WeakReference<View> (checkBox) };
         CommandContext ctx = new () { Command = Command.Activate, Source = new WeakReference<View> (checkBox), Binding = keyBinding };
 
         checkBox.InvokeCommand (Command.Activate, ctx);
@@ -462,7 +462,7 @@ public class CommandBubblingTests
         menuBar.Layout ();
 
         // Act
-        MouseBinding mouseBinding = new ([Command.Accept], MouseFlags.LeftButtonDoubleClicked) { Source = checkBox };
+        MouseBinding mouseBinding = new ([Command.Accept], MouseFlags.LeftButtonDoubleClicked) { Source = new WeakReference<View> (checkBox) };
         CommandContext ctx = new () { Command = Command.Accept, Source = new WeakReference<View> (checkBox), Binding = mouseBinding };
 
         checkBox.InvokeCommand (Command.Accept, ctx);
@@ -508,7 +508,7 @@ public class CommandBubblingTests
         superView.Layout ();
 
         // Act
-        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Enter, Source = subView };
+        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Enter, Source = new WeakReference<View> (subView) };
         CommandContext ctx = new () { Command = Command.Activate, Source = new WeakReference<View> (subView), Binding = keyBinding };
 
         subView.InvokeCommand (Command.Activate, ctx);

--- a/Tests/UnitTestsParallelizable/ViewBase/CommandContextTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/CommandContextTests.cs
@@ -74,19 +74,20 @@ public class CommandContextTests
         Assert.NotNull (iCtx.Source);
     }
 
+    // Claude - Opus 4.6
     [Fact]
-    public void Source_IsMutable_ThroughInterface ()
+    public void Source_IsImmutable_ThroughInterface ()
     {
         View originalSource = new () { Id = "original" };
-        View newSource = new () { Id = "new" };
 
         CommandContext ctx = new () { Command = Command.Accept, Source = new WeakReference<View> (originalSource) };
 
         ICommandContext iCtx = ctx;
-        iCtx.Source = new WeakReference<View> (newSource);
 
-        // Phase 2: Temporarily commented - will fix in Phase 4
-        // Assert.Equal (newSource, iCtx.Source);
+        // Source is read-only through the interface — immutability is enforced
+        Assert.NotNull (iCtx.Source);
+        iCtx.Source.TryGetTarget (out View? retrieved);
+        Assert.Equal ("original", retrieved?.Id);
     }
 
     #endregion
@@ -115,7 +116,7 @@ public class CommandContextTests
     [Fact]
     public void PatternMatching_MouseBinding_WithMouseEvent_Works ()
     {
-        MouseBinding mouseBinding = new ([Command.Activate], MouseFlags.LeftButtonClicked) { Source = new View { Id = "mouseSource" } };
+        MouseBinding mouseBinding = new ([Command.Activate], MouseFlags.LeftButtonClicked) { Source = new WeakReference<View> (new View { Id = "mouseSource" }) };
         mouseBinding.MouseEvent = new Mouse { Flags = MouseFlags.LeftButtonClicked, Position = new Point (10, 20) };
 
         ICommandContext ctx = new CommandContext { Command = Command.Activate, Source = new WeakReference<View> (new View ()), Binding = mouseBinding };
@@ -172,7 +173,7 @@ public class CommandContextTests
         View bindingSource = new () { Id = "bindingSource" };
         View contextSource = new () { Id = "contextSource" };
 
-        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.A, Source = bindingSource };
+        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.A, Source = new WeakReference<View> (bindingSource) };
 
         CommandContext ctx = new () { Command = Command.Activate, Source = new WeakReference<View> (contextSource), Binding = keyBinding };
 
@@ -183,7 +184,9 @@ public class CommandContextTests
 
         if (ctx.Binding is KeyBinding kb)
         {
-            Assert.Equal ("bindingSource", kb.Source?.Id);
+            View? kbSource = null;
+            Assert.True (kb.Source?.TryGetTarget (out kbSource) == true);
+            Assert.Equal ("bindingSource", kbSource?.Id);
         }
         else
         {
@@ -197,7 +200,7 @@ public class CommandContextTests
         View bindingSource = new () { Id = "bindingSource" };
         View contextSource = new () { Id = "contextSource" };
 
-        MouseBinding mouseBinding = new ([Command.Activate], MouseFlags.LeftButtonClicked) { Source = bindingSource };
+        MouseBinding mouseBinding = new ([Command.Activate], MouseFlags.LeftButtonClicked) { Source = new WeakReference<View> (bindingSource) };
 
         CommandContext ctx = new () { Command = Command.Activate, Source = new WeakReference<View> (contextSource), Binding = mouseBinding };
 
@@ -208,7 +211,9 @@ public class CommandContextTests
 
         if (ctx.Binding is MouseBinding mb)
         {
-            Assert.Equal ("bindingSource", mb.Source?.Id);
+            View? mbSource = null;
+            Assert.True (mb.Source?.TryGetTarget (out mbSource) == true);
+            Assert.Equal ("bindingSource", mbSource?.Id);
         }
         else
         {
@@ -223,7 +228,7 @@ public class CommandContextTests
     [Fact]
     public void CommandEventArgs_Context_WithKeyBinding_Works ()
     {
-        KeyBinding keyBinding = new ([Command.Accept]) { Key = Key.Enter, Source = new View { Id = "keySource" } };
+        KeyBinding keyBinding = new ([Command.Accept]) { Key = Key.Enter, Source = new WeakReference<View> (new View { Id = "keySource" }) };
 
         CommandContext ctx = new () { Command = Command.Accept, Source = new WeakReference<View> (new View { Id = "invoker" }), Binding = keyBinding };
 
@@ -245,7 +250,7 @@ public class CommandContextTests
     [Fact]
     public void CommandEventArgs_Context_WithMouseBinding_Works ()
     {
-        MouseBinding mouseBinding = new ([Command.Activate], MouseFlags.RightButtonClicked) { Source = new View { Id = "mouseSource" } };
+        MouseBinding mouseBinding = new ([Command.Activate], MouseFlags.RightButtonClicked) { Source = new WeakReference<View> (new View { Id = "mouseSource" }) };
 
         CommandContext ctx = new () { Command = Command.Activate, Source = new WeakReference<View> (new View { Id = "invoker" }), Binding = mouseBinding };
 
@@ -325,7 +330,9 @@ public class CommandContextTests
         // Pattern match on Binding from the interface
         if (ctx.Binding is CommandBinding ib)
         {
-            Assert.Equal ("programmatic", ib.Source?.Id);
+            View? sv = null;
+            Assert.True (ib.Source?.TryGetTarget (out sv) == true);
+            Assert.Equal ("programmatic", sv?.Id);
             Assert.Equal ("data", ib.Data);
         }
         else
@@ -427,44 +434,78 @@ public class CommandContextTests
         Assert.Equal ("weakRefTest", retrievedView?.Id);
     }
 
+    // Claude - Opus 4.6
     [Fact]
-    public void Source_WeakReference_CanBeUpdated ()
+    public void Source_WithExpression_CreatesNewContext ()
     {
         View originalView = new () { Id = "original" };
         View newView = new () { Id = "new" };
 
         CommandContext ctx = new () { Command = Command.Accept, Source = new WeakReference<View> (originalView) };
 
-        // Update Source
-        ctx.Source = new WeakReference<View> (newView);
+        // Use `with` expression to create a new context with different Source
+        CommandContext updated = ctx with { Source = new WeakReference<View> (newView) };
 
-        View? retrievedView = null;
-        ctx.Source?.TryGetTarget (out retrievedView);
-        Assert.Equal ("new", retrievedView?.Id);
+        // Original is unchanged
+        View? originalRetrieved = null;
+        ctx.Source?.TryGetTarget (out originalRetrieved);
+        Assert.Equal ("original", originalRetrieved?.Id);
+
+        // Updated has new source
+        View? updatedRetrieved = null;
+        updated.Source?.TryGetTarget (out updatedRetrieved);
+        Assert.Equal ("new", updatedRetrieved?.Id);
     }
 
     #endregion
 
-    #region Command Property Mutability Tests
+    #region Command Property Immutability Tests
 
+    // Claude - Opus 4.6
     [Fact]
-    public void Command_Property_CanBeChanged ()
+    public void WithCommand_CreatesNewContext_PreservesOtherFields ()
     {
-        CommandContext ctx = new () { Command = Command.Accept };
+        View sourceView = new () { Id = "source" };
+        KeyBinding binding = new ([Command.Accept]) { Key = Key.Enter };
 
-        ctx.Command = Command.Activate;
+        CommandContext ctx = new ()
+        {
+            Command = Command.Accept,
+            Source = new WeakReference<View> (sourceView),
+            Binding = binding,
+            Routing = CommandRouting.BubblingUp
+        };
 
-        Assert.Equal (Command.Activate, ctx.Command);
+        CommandContext updated = ctx.WithCommand (Command.Activate);
+
+        // Original unchanged
+        Assert.Equal (Command.Accept, ctx.Command);
+
+        // Updated has new command, everything else preserved
+        Assert.Equal (Command.Activate, updated.Command);
+        Assert.Equal (ctx.Source, updated.Source);
+        Assert.Equal (ctx.Binding, updated.Binding);
+        Assert.Equal (CommandRouting.BubblingUp, updated.Routing);
     }
 
+    // Claude - Opus 4.6
     [Fact]
-    public void Command_Property_CanBeChangedThroughInterface ()
+    public void WithRouting_CreatesNewContext_PreservesOtherFields ()
     {
-        ICommandContext ctx = new CommandContext { Command = Command.Accept };
+        CommandContext ctx = new ()
+        {
+            Command = Command.Accept,
+            Routing = CommandRouting.Direct
+        };
 
-        ctx.Command = Command.HotKey;
+        CommandContext updated = ctx.WithRouting (CommandRouting.DispatchingDown);
 
-        Assert.Equal (Command.HotKey, ctx.Command);
+        // Original unchanged
+        Assert.Equal (CommandRouting.Direct, ctx.Routing);
+
+        // Updated has new routing
+        Assert.Equal (CommandRouting.DispatchingDown, updated.Routing);
+        Assert.Equal (Command.Accept, updated.Command);
     }
 
     #endregion

--- a/Tests/UnitTestsParallelizable/ViewBase/ViewCommandTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/ViewCommandTests.cs
@@ -1289,7 +1289,7 @@ public class ViewCommandTests
         superView.TestBubbleDown (target, ctx);
 
         Assert.NotNull (receivedCtx);
-        Assert.True (receivedCtx!.IsBubblingDown);
+        Assert.Equal (CommandRouting.DispatchingDown, receivedCtx!.Routing);
     }
 
     // Claude - Opus 4.6
@@ -1447,8 +1447,8 @@ public class ViewCommandTests
         var superViewActivatingCount = 0;
         superView.Activating += (_, _) => superViewActivatingCount++;
 
-        // Invoke Activate on subView with IsBubblingDown = true
-        CommandContext ctx = new (Command.Activate, new WeakReference<View> (subView), null) { IsBubblingDown = true };
+        // Invoke Activate on subView with Routing = DispatchingDown
+        CommandContext ctx = new (Command.Activate, new WeakReference<View> (subView), null) { Routing = CommandRouting.DispatchingDown };
         subView.InvokeCommand (Command.Activate, ctx);
 
         // SuperView should NOT receive the event

--- a/Tests/UnitTestsParallelizable/Views/MenuBarTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/MenuBarTests.cs
@@ -1,9 +1,241 @@
+using Terminal.Gui.Drawing;
 using Terminal.Gui.Testing;
 
 namespace ViewsTests;
 
 public class MenuBarTests
 {
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     Verifies that clicking the "Error" checkbox in the OptionSelector&lt;Schemes&gt; inside
+    ///     MenuBar.EnableForDesign's Preferences SubMenu changes Value from 0 (Base) to 4 (Error).
+    ///     This exercises the full Shortcut → OptionSelector dispatch path inside a PopoverMenu SubMenu.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_SubMenu_Click_Sets_Correct_Value ()
+    {
+        // Arrange
+        VirtualTimeProvider time = new ();
+        using IApplication app = Application.Create (time);
+        app.Init (DriverRegistry.Names.ANSI);
+        IRunnable runnable = new Runnable ();
+
+        View hostView = new ()
+        {
+            Id = "host",
+            CanFocus = true,
+            Width = Dim.Fill (),
+            Height = Dim.Fill ()
+        };
+
+        MenuBar menuBar = new () { Id = "menuBar" };
+        menuBar.EnableForDesign (ref hostView);
+        hostView.Add (menuBar);
+
+        ((View)runnable).Add (hostView);
+        app.Begin (runnable);
+
+        // Find the OptionSelector<Schemes> in the menu hierarchy
+        // It's in File → Preferences → "mutuallyExclusiveOptions" MenuItem
+        MenuBarItem fileItem = menuBar.SubViews.OfType<MenuBarItem> ().First ();
+        Assert.NotNull (fileItem.PopoverMenu);
+
+        // Open the File menu
+        Point fileScreenPos = fileItem.FrameToScreen ().Location;
+        app.InjectSequence (InputInjectionExtensions.LeftButtonClick (fileScreenPos));
+        Assert.True (menuBar.IsOpen (), "File menu should be open");
+
+        // Find the "Preferences" MenuItem which has a SubMenu
+        Menu? rootMenu = fileItem.PopoverMenu!.Root;
+        Assert.NotNull (rootMenu);
+
+        MenuItem? prefsItem = rootMenu!.SubViews.OfType<MenuItem> ()
+                                       .FirstOrDefault (mi => mi.Title == "_Preferences");
+        Assert.NotNull (prefsItem);
+        Assert.NotNull (prefsItem!.SubMenu);
+
+        // Make Preferences SubMenu visible by navigating to it
+        prefsItem.SetFocus ();
+
+        // Find the MenuItem with the OptionSelector CommandView
+        MenuItem? optionMenuItem = prefsItem.SubMenu!.SubViews.OfType<MenuItem> ()
+                                            .FirstOrDefault (mi => mi.Id == "mutuallyExclusiveOptions");
+        Assert.NotNull (optionMenuItem);
+
+        OptionSelector<Schemes>? optionSelector = optionMenuItem!.CommandView as OptionSelector<Schemes>;
+        Assert.NotNull (optionSelector);
+        Assert.Equal (Schemes.Base, optionSelector!.Value);
+
+        // Find the "Error" checkbox (index 4)
+        CheckBox? errorCheckBox = optionSelector.SubViews.OfType<CheckBox> ()
+                                                .FirstOrDefault (cb => (int)cb.Data! == (int)Schemes.Error);
+        Assert.NotNull (errorCheckBox);
+
+        // Subscribe to ValueChanged
+        Schemes? newValue = null;
+        var valueChangedCount = 0;
+
+        optionSelector.ValueChanged += (_, args) =>
+                                       {
+                                           newValue = args.Value;
+                                           valueChangedCount++;
+                                       };
+
+        // Act — click on the Error checkbox via the MenuItem (simulates real mouse click
+        // which hits the Shortcut/MenuItem level and dispatches down to CommandView)
+        errorCheckBox!.SetFocus ();
+        Point errorScreenPos = errorCheckBox.FrameToScreen ().Location;
+
+        // Use InjectMouse to simulate the full mouse pipeline (LeftButtonPressed + LeftButtonReleased)
+        // which goes through the Shortcut dispatch path, not directly to the CheckBox
+        app.InjectMouse (new Mouse { ScreenPosition = errorScreenPos, Flags = MouseFlags.LeftButtonPressed });
+        app.InjectMouse (new Mouse { ScreenPosition = errorScreenPos, Flags = MouseFlags.LeftButtonReleased });
+
+        // Assert — Value should change from Base (0) to Error (4), not to Menu (1)
+        Assert.Equal (1, valueChangedCount);
+        Assert.Equal (Schemes.Error, newValue);
+        Assert.Equal (Schemes.Error, optionSelector.Value);
+
+        menuBar.Dispose ();
+    }
+
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     Verifies that pressing Space on the "Error" checkbox in the OptionSelector&lt;Schemes&gt;
+    ///     inside MenuBar.EnableForDesign's Preferences SubMenu changes Value correctly.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_SubMenu_Space_Sets_Correct_Value ()
+    {
+        // Arrange
+        VirtualTimeProvider time = new ();
+        using IApplication app = Application.Create (time);
+        app.Init (DriverRegistry.Names.ANSI);
+        IRunnable runnable = new Runnable ();
+
+        View hostView = new ()
+        {
+            Id = "host",
+            CanFocus = true,
+            Width = Dim.Fill (),
+            Height = Dim.Fill ()
+        };
+
+        MenuBar menuBar = new () { Id = "menuBar" };
+        menuBar.EnableForDesign (ref hostView);
+        hostView.Add (menuBar);
+
+        ((View)runnable).Add (hostView);
+        app.Begin (runnable);
+
+        // Navigate to the OptionSelector
+        MenuBarItem fileItem = menuBar.SubViews.OfType<MenuBarItem> ().First ();
+        Point fileScreenPos = fileItem.FrameToScreen ().Location;
+        app.InjectSequence (InputInjectionExtensions.LeftButtonClick (fileScreenPos));
+
+        Menu? rootMenu = fileItem.PopoverMenu!.Root;
+        MenuItem? prefsItem = rootMenu!.SubViews.OfType<MenuItem> ()
+                                       .FirstOrDefault (mi => mi.Title == "_Preferences");
+        prefsItem!.SetFocus ();
+
+        MenuItem? optionMenuItem = prefsItem.SubMenu!.SubViews.OfType<MenuItem> ()
+                                            .FirstOrDefault (mi => mi.Id == "mutuallyExclusiveOptions");
+        OptionSelector<Schemes>? optionSelector = optionMenuItem!.CommandView as OptionSelector<Schemes>;
+        Assert.Equal (Schemes.Base, optionSelector!.Value);
+
+        CheckBox? errorCheckBox = optionSelector.SubViews.OfType<CheckBox> ()
+                                                .FirstOrDefault (cb => (int)cb.Data! == (int)Schemes.Error);
+
+        Schemes? newValue = null;
+        var valueChangedCount = 0;
+
+        optionSelector.ValueChanged += (_, args) =>
+                                       {
+                                           newValue = args.Value;
+                                           valueChangedCount++;
+                                       };
+
+        // Act — focus Error checkbox and press Space via the MenuItem context
+        // Space is bound to Command.Activate on CheckBox. When inside a MenuItem/Shortcut,
+        // the key goes through the Shortcut's key binding scope.
+        errorCheckBox!.SetFocus ();
+        app.InjectKey (Key.Space);
+
+        // Assert — Value should change to Error (4)
+        Assert.Equal (1, valueChangedCount);
+        Assert.Equal (Schemes.Error, newValue);
+        Assert.Equal (Schemes.Error, optionSelector.Value);
+
+        menuBar.Dispose ();
+    }
+
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     Verifies that pressing Enter on the "Error" checkbox in the OptionSelector&lt;Schemes&gt;
+    ///     inside MenuBar.EnableForDesign's Preferences SubMenu changes Value correctly.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_SubMenu_Enter_Sets_Correct_Value ()
+    {
+        // Arrange
+        VirtualTimeProvider time = new ();
+        using IApplication app = Application.Create (time);
+        app.Init (DriverRegistry.Names.ANSI);
+        IRunnable runnable = new Runnable ();
+
+        View hostView = new ()
+        {
+            Id = "host",
+            CanFocus = true,
+            Width = Dim.Fill (),
+            Height = Dim.Fill ()
+        };
+
+        MenuBar menuBar = new () { Id = "menuBar" };
+        menuBar.EnableForDesign (ref hostView);
+        hostView.Add (menuBar);
+
+        ((View)runnable).Add (hostView);
+        app.Begin (runnable);
+
+        // Navigate to the OptionSelector
+        MenuBarItem fileItem = menuBar.SubViews.OfType<MenuBarItem> ().First ();
+        Point fileScreenPos = fileItem.FrameToScreen ().Location;
+        app.InjectSequence (InputInjectionExtensions.LeftButtonClick (fileScreenPos));
+
+        Menu? rootMenu = fileItem.PopoverMenu!.Root;
+        MenuItem? prefsItem = rootMenu!.SubViews.OfType<MenuItem> ()
+                                       .FirstOrDefault (mi => mi.Title == "_Preferences");
+        prefsItem!.SetFocus ();
+
+        MenuItem? optionMenuItem = prefsItem.SubMenu!.SubViews.OfType<MenuItem> ()
+                                            .FirstOrDefault (mi => mi.Id == "mutuallyExclusiveOptions");
+        OptionSelector<Schemes>? optionSelector = optionMenuItem!.CommandView as OptionSelector<Schemes>;
+        Assert.Equal (Schemes.Base, optionSelector!.Value);
+
+        CheckBox? errorCheckBox = optionSelector.SubViews.OfType<CheckBox> ()
+                                                .FirstOrDefault (cb => (int)cb.Data! == (int)Schemes.Error);
+
+        Schemes? newValue = null;
+        var valueChangedCount = 0;
+
+        optionSelector.ValueChanged += (_, args) =>
+                                       {
+                                           newValue = args.Value;
+                                           valueChangedCount++;
+                                       };
+
+        // Act — focus Error checkbox and press Enter via the MenuItem context
+        errorCheckBox!.SetFocus ();
+        app.InjectKey (Key.Enter);
+
+        // Assert — Value should change to Error (4)
+        Assert.True (valueChangedCount >= 1, "ValueChanged should fire at least once");
+        Assert.Equal (Schemes.Error, optionSelector.Value);
+
+        menuBar.Dispose ();
+    }
+
     // Claude - Opus 4.6
     [Fact]
     public void Mouse_Click_Activates_And_Opens ()

--- a/Tests/UnitTestsParallelizable/Views/OptionSelectorTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/OptionSelectorTests.cs
@@ -247,6 +247,65 @@ public class OptionSelectorTests
         Assert.Equal (CheckState.UnChecked, optionSelector.SubViews.OfType<CheckBox> ().First (cb => cb.Title == "Option1").Value);
     }
 
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     MINIMAL REPRO: OptionSelector inside a Shortcut with Application context.
+    ///     LeftButtonReleased on "C" checkbox propagates to Shortcut (CheckBox doesn't handle it),
+    ///     Shortcut dispatches down to OptionSelector. Value should change to 2 ("C"), not Cycle to 1.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_Shortcut_MouseClick_Selects_Correct_Item ()
+    {
+        // Need Application context for focus propagation (LeftButtonPressed sets focus)
+        VirtualTimeProvider time = new ();
+        using IApplication app = Application.Create (time);
+        app.Init (DriverRegistry.Names.ANSI);
+        IRunnable runnable = new Runnable ();
+
+        OptionSelector optionSelector = new () { Labels = ["A", "B", "C"] };
+        Shortcut shortcut = new () { Key = Key.F5, CommandView = optionSelector };
+
+        ((View)runnable).Add (shortcut);
+        app.Begin (runnable);
+
+        Assert.Equal (0, optionSelector.Value);
+
+        // Find "C" checkbox (index 2)
+        CheckBox checkBoxC = optionSelector.SubViews.OfType<CheckBox> ().First (cb => cb.Title == "C");
+
+        // Simulate: LeftButtonPressed (sets focus) then LeftButtonReleased (triggers Activate on Shortcut)
+        System.Drawing.Point pos = checkBoxC.FrameToScreen ().Location;
+        app.InjectMouse (new Mouse { ScreenPosition = pos, Position = pos, Flags = MouseFlags.LeftButtonPressed });
+        app.InjectMouse (new Mouse { ScreenPosition = pos, Position = pos, Flags = MouseFlags.LeftButtonReleased });
+
+        // Assert: Value should be 2 ("C"), not 1 (Cycle from 0)
+        Assert.Equal (2, optionSelector.Value);
+    }
+
+    // Claude - Opus 4.6
+    /// <summary>
+    ///     OptionSelector inside a Shortcut. LeftButtonClicked (which CheckBox handles) on a
+    ///     non-selected checkbox. This is the event that the real driver synthesizes after
+    ///     Pressed+Released. If this fails, the Shortcut dispatch is intercepting it.
+    /// </summary>
+    [Fact]
+    public void OptionSelector_In_Shortcut_LeftButtonClicked_Selects_Correct_Item ()
+    {
+        OptionSelector optionSelector = new () { Labels = ["A", "B", "C"] };
+        Shortcut shortcut = new () { Key = Key.F5, CommandView = optionSelector };
+        shortcut.Layout ();
+
+        Assert.Equal (0, optionSelector.Value);
+
+        CheckBox checkBoxC = optionSelector.SubViews.OfType<CheckBox> ().First (cb => cb.Title == "C");
+
+        // LeftButtonClicked — this is what CheckBox binds to Command.Activate
+        Mouse mouse = new () { Position = checkBoxC.Frame.Location, Flags = MouseFlags.LeftButtonClicked };
+        checkBoxC.NewMouseEvent (mouse);
+
+        Assert.Equal (2, optionSelector.Value);
+    }
+
     [Fact]
     public void Values_ShouldUseOptions_WhenValuesIsNull ()
     {

--- a/Tests/UnitTestsParallelizable/Views/PopoverMenuTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/PopoverMenuTests.cs
@@ -158,7 +158,7 @@ public class PopoverMenuTests
             = BuildOptionSelectorInMenuBarHierarchy ();
 
         // Act: Simulate keyboard activation via Space key binding
-        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = secondCheckBox };
+        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = new WeakReference<View> (secondCheckBox) };
 
         CommandContext ctx = new ()
         {
@@ -190,7 +190,7 @@ public class PopoverMenuTests
             = BuildOptionSelectorInMenuBarHierarchy ();
 
         // Act: Simulate mouse activation via LeftButtonReleased binding
-        MouseBinding mouseBinding = new ([Command.Activate], MouseFlags.LeftButtonReleased) { Source = secondCheckBox };
+        MouseBinding mouseBinding = new ([Command.Activate], MouseFlags.LeftButtonReleased) { Source = new WeakReference<View> (secondCheckBox) };
 
         CommandContext ctx = new ()
         {
@@ -252,7 +252,7 @@ public class PopoverMenuTests
             = BuildOptionSelectorInMenuBarHierarchy ();
 
         // Act
-        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = secondCheckBox };
+        KeyBinding keyBinding = new ([Command.Activate]) { Key = Key.Space, Source = new WeakReference<View> (secondCheckBox) };
 
         CommandContext ctx = new ()
         {

--- a/Tests/UnitTestsParallelizable/Views/ShortcutTests.Command.cs
+++ b/Tests/UnitTestsParallelizable/Views/ShortcutTests.Command.cs
@@ -790,12 +790,17 @@ public partial class ShortcutTests
         shortcut.InvokeCommand (Command.Activate, ctx);
 
         // Assert - Shortcut.Activating fires first (notification before dispatch),
-        // then BubbleDown fires CommandView events, then Shortcut.Activated via deferred callback.
+        // then BubbleDown fires CommandView events. Shortcut.Activated fires from
+        // CommandView_Activated (subscribed before test handler), so it interleaves
+        // with CheckBox.Activated.
         Assert.Equal (4, eventLog.Count);
         Assert.Equal ("Shortcut.Activating", eventLog [0]);
         Assert.Equal ("CheckBox.Activating", eventLog [1]);
-        Assert.Equal ("CheckBox.Activated", eventLog [2]);
-        Assert.Equal ("Shortcut.Activated", eventLog [3]);
+
+        // Shortcut.Activated fires during CheckBox.Activated event dispatch
+        // (CommandView_Activated subscribed before test handler)
+        Assert.Equal ("Shortcut.Activated", eventLog [2]);
+        Assert.Equal ("CheckBox.Activated", eventLog [3]);
 
         // CheckBox should have toggled
         Assert.Equal (CheckState.Checked, checkBox.Value);

--- a/Tests/UnitTestsParallelizable/Views/ShortcutTests.Command.cs
+++ b/Tests/UnitTestsParallelizable/Views/ShortcutTests.Command.cs
@@ -753,11 +753,12 @@ public partial class ShortcutTests
     /// <summary>
     ///     Verifies correct event ordering for compound views in Shortcut when activation
     ///     is triggered via BubbleDown (e.g., clicking on Shortcut's HelpView area).
-    ///     OnActivating calls BubbleDown when the activation source is not the CommandView.
+    ///     The framework dispatches BubbleDown after OnActivating but before Activated.
     ///     Expected order:
-    ///     1. Shortcut.Activating (fires in RaiseActivating, after OnActivating/BubbleDown)
-    ///     2. Shortcut.Activated (direct path, not deferred since IsBubblingUp is false)
-    ///     BubbleDown also triggers CommandView events, but inside OnActivating (before Shortcut.Activating).
+    ///     1. Shortcut.Activating (fires from RaiseActivating before framework dispatch)
+    ///     2. CheckBox.Activating (from BubbleDown during framework dispatch, after Activating event)
+    ///     3. CheckBox.Activated
+    ///     4. Shortcut.Activated (from CommandView_Activated deferred callback)
     /// </summary>
     [Fact]
     public void BubbleDown_Activate_Event_Ordering_With_Binding_Source ()
@@ -788,12 +789,12 @@ public partial class ShortcutTests
         CommandContext ctx = new (Command.Activate, new WeakReference<View> (shortcut), binding);
         shortcut.InvokeCommand (Command.Activate, ctx);
 
-        // Assert - BubbleDown fires CommandView events during OnActivating (before Shortcut.Activating),
-        // then Shortcut.Activating fires, then Shortcut.Activated (direct path).
+        // Assert - Shortcut.Activating fires first (notification before dispatch),
+        // then BubbleDown fires CommandView events, then Shortcut.Activated via deferred callback.
         Assert.Equal (4, eventLog.Count);
-        Assert.Equal ("CheckBox.Activating", eventLog [0]);
-        Assert.Equal ("CheckBox.Activated", eventLog [1]);
-        Assert.Equal ("Shortcut.Activating", eventLog [2]);
+        Assert.Equal ("Shortcut.Activating", eventLog [0]);
+        Assert.Equal ("CheckBox.Activating", eventLog [1]);
+        Assert.Equal ("CheckBox.Activated", eventLog [2]);
         Assert.Equal ("Shortcut.Activated", eventLog [3]);
 
         // CheckBox should have toggled
@@ -848,15 +849,16 @@ public partial class ShortcutTests
         CommandContext ctx = new (Command.Activate, new WeakReference<View> (firstCheckBox), binding);
         firstCheckBox.InvokeCommand (Command.Activate, ctx);
 
-        // Assert - Value changes exactly once. FlagSelector consumes the bubble in OnActivating
-        // (preventing CheckBox double-toggle). This means Shortcut.Activating doesn't fire
-        // (bubble doesn't reach Shortcut), but Shortcut.Activated fires via the deferred path
-        // (FlagSelector.RaiseActivated → CommandView_Activated). FlagSelector.Activating event
-        // doesn't fire because OnActivating consumes before the event is raised.
+        // Assert - Value changes exactly once. In the new design, the Activating event always fires
+        // as a notification before the framework dispatch consumes the command. This means
+        // FlagSelector.Activating fires (subscribers get a chance to cancel before dispatch),
+        // but Shortcut.Activating doesn't fire (bubble doesn't reach Shortcut because FlagSelector
+        // consumes during dispatch). Shortcut.Activated fires via the deferred path
+        // (FlagSelector.RaiseActivated → CommandView_Activated).
         Assert.Equal (1, valueChangedCount);
         Assert.Equal (0, shortcutActivatingCount);
         Assert.Equal (1, shortcutActivatedCount);
-        Assert.Equal (0, flagSelectorActivatingCount);
+        Assert.Equal (1, flagSelectorActivatingCount);
 
         // The checkbox should be checked (toggled once, not toggled twice back to unchecked)
         Assert.Equal (CheckState.Checked, firstCheckBox.Value);

--- a/plans/command-system-redesign-requirements.md
+++ b/plans/command-system-redesign-requirements.md
@@ -721,3 +721,98 @@ Each phase is independently shippable and testable.
 
 3. **`CommandBridge` is one-way.** Remote fires event → owner receives command.
    If bidirectional is needed, create two bridges.
+
+---
+
+## Implementation Status (Updated 2026-02-19)
+
+### Completed
+
+| Phase | Status | Commit | Notes |
+|-------|--------|--------|-------|
+| **A — Foundation** | Done | `be22792b2` | As planned. All types added, WeakRef migration complete. |
+| **B — Dispatch** | Done | `bc48676af` | Significant deviations from plan — see below. |
+| **C — Bridge** | Done | `9045e3050` | CommandBridge implemented. Only MenuBarItem migrated (pragmatic scope). |
+| **D — Outcome** | **Deferred** | — | 267 `AddCommand` call sites across 28 files. Conversion shims exist for incremental migration. |
+| **E — Cleanup** | Done | `4262441ca` | IsBubblingUp/IsBubblingDown removed. Route tracing not yet added. |
+
+### Deviations from Plan
+
+#### Phase B — Dispatch Deviations
+
+1. **Shortcut still uses `CommandView_Activated` callback.**
+   The plan said "No event-subscription machinery needed" for deferred completion, but this
+   proved incorrect. When `IsBubblingUp`, the originator (CheckBox) hasn't called `RaiseActivated`
+   yet when Shortcut's `DefaultActivateHandler` runs. `CommandView_Activated` fires AFTER the
+   originator completes, ensuring correct ordering (CheckBox toggles before Shortcut.Action reads
+   the value). The callback is simplified from the old version (no `_activationBubbledUp` flag).
+
+2. **ConsumeDispatch=true does NOT BubbleDown for IsBubblingUp.**
+   The plan's framework behavior said "Dispatch to target with Routing = DispatchingDown"
+   unconditionally. In practice, for consume views (OptionSelector, FlagSelector), dispatching
+   back to the originating CheckBox would cause double-toggle. The actual behavior:
+   - IsBubblingUp → mark as consumed, NO BubbleDown (OnActivated handles state mutation)
+   - Direct/programmatic → BubbleDown to target (forwards the command)
+
+3. **Selectors dispatch Activate only, not Accept.**
+   The plan showed `GetDispatchTarget` returning unconditionally. In practice, Accept must bubble
+   normally through the Menu hierarchy (MenuItem → Menu → PopoverMenu → MenuBarItem → MenuBar).
+   Selectors check `ctx?.Command != Command.Activate` and return null for non-Activate commands.
+
+4. **Selectors use context-dependent dispatch targets.**
+   The plan showed `GetDispatchTarget => Focused`. In practice, `Focused` is null in tests without
+   Application.Init. Selectors now return the source CheckBox (from `ctx.Source`) for IsBubblingUp,
+   and `Focused` for direct invocations.
+
+5. **FlagSelector retains `_suppressHotKeyActivate`.**
+   The plan said this flag was unnecessary because "DefaultHotKeyHandler calls InvokeCommand(Activate)
+   without a binding." In practice, DefaultHotKeyHandler passes the original binding through
+   (`ctx?.Binding`), so the binding guard doesn't suppress dispatch. The flag is checked in
+   `GetDispatchTarget` and returns null to skip dispatch when set.
+
+6. **Event ordering changed: Activating fires BEFORE dispatch.**
+   The plan placed dispatch at step 4 (after OnActivating + Activating event). The old code
+   dispatched in OnActivating (step 2, before the event). This means subscribers now get
+   notified BEFORE dispatch occurs — they can cancel before the target is activated. Tests
+   were updated to reflect the new ordering.
+
+7. **Binding guard is ConsumeDispatch-dependent.**
+   The plan said "skip dispatch for programmatic invocations (no binding)." This is only needed
+   for relay dispatch (ConsumeDispatch=false, e.g., Shortcut) to prevent loops. Consume dispatch
+   views (selectors) need programmatic invocations to dispatch so `InvokeCommand(Activate)`
+   forwards to the focused item.
+
+#### Phase C — Bridge Deviations
+
+1. **Only MenuBarItem migrated, not Menu or PopoverMenu.**
+   The plan called for replacing all manual event wiring in Menu.OnSubViewAdded and
+   PopoverMenu.Root setter. These are same-tree (containment) wiring, not cross-boundary.
+   CommandBridge is designed for cross-boundary routing (non-containment). The existing
+   same-tree wiring works correctly and is lower risk to leave in place.
+
+2. **ItemSelected event on Menu not added.**
+   The plan proposed separating "close the menu" concern from command routing. The current
+   pattern (menuItem.Activated → Menu.RaiseAccepted → PopoverMenu closes) works correctly.
+   This can be added later as a separate improvement.
+
+3. **`RaiseAccepted`/`RaiseActivated` made `internal protected`.**
+   CommandBridge needs to call these from outside the View class hierarchy. The plan didn't
+   address this access issue. Changed from `protected` to `internal protected`.
+
+#### Phase D — Deferred
+
+267 `AddCommand` handler signatures across 28 files need `bool?` → `CommandOutcome` migration.
+This is purely mechanical with no behavioral change. The `CommandOutcomeExtensions.ToBool()`
+and `ToOutcome()` shims enable incremental migration. Recommended approach: migrate one file
+at a time with a sub-agent, verifying tests after each file.
+
+#### Phase E — Partial
+
+Route tracing (`TraceRoute` with `[Conditional("DEBUG")]`) not yet implemented. The
+`IsBubblingUp`/`IsBubblingDown` removal is complete. `docfx/docs/command.md` not yet updated.
+
+### Test Results
+
+- **UnitTestsParallelizable**: 13,980 passed, 0 failed, 22 skipped
+- **UnitTests**: 1,001 passed, 0 failed, 22 skipped
+- **Total**: 14,981 passed, 0 failed


### PR DESCRIPTION
## Summary

Implements the command system redesign from `plans/command-system-redesign-requirements.md` (Phases A, B, C, E). Phase D (CommandOutcome migration of 267 AddCommand call sites) is deferred for incremental migration.

### Phase A — Foundation Types
- `CommandOutcome` enum (NotHandled/HandledStop/HandledContinue) with `bool?` conversion shims
- `CommandRouting` enum (Direct/BubblingUp/DispatchingDown/Bridged)
- `CommandContext` → immutable `readonly record struct` with `WithCommand`/`WithRouting` methods
- `ICommandBinding.Source` → `WeakReference<View>?` (fixes memory leak where bindings held strong refs to views)

### Phase B — Dispatch Pattern (GetDispatchTarget/ConsumeDispatch)
- `GetDispatchTarget` virtual on View: returns the SubView to dispatch commands to
- `ConsumeDispatch` virtual on View: true = consume originator, false = relay
- Framework dispatch integrated into `RaiseActivating`/`RaiseAccepting` (between events and TryBubbleUp)
- **Shortcut**: ~120 lines deleted, replaced by `GetDispatchTarget => CommandView`
- **OptionSelector**: ~23 lines deleted, `ConsumeDispatch => true`
- **FlagSelector**: ~50 lines deleted, `ConsumeDispatch => true`

### Phase C — CommandBridge
- New `CommandBridge` class for cross-boundary command routing (e.g., MenuBarItem ↔ PopoverMenu)
- Weak references prevent GC leaks; auto-teardown on Dispose
- MenuBarItem migrated to use `CommandBridge.Connect` (replaces manual event wiring)

### Phase E — Cleanup
- Removed `IsBubblingUp`/`IsBubblingDown` compat properties from `ICommandContext`/`CommandContext`
- All routing checks now use `CommandRouting` enum exclusively

## Test plan
- [x] All 13,980 parallelizable tests pass (0 failures)
- [x] All 1,001 unit tests pass (0 failures)
- [x] UICatalog and all examples build clean
- [ ] Manual testing of UICatalog Shortcuts, Menus, Selectors, Dialogs scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core input/command routing, bubbling/dispatch semantics, and menu popover command propagation; regressions could broadly affect keyboard/mouse handling and event ordering across many widgets.
> 
> **Overview**
> Implements the next phases of the command-system redesign by making command invocation context/bindings *weakly-referenced* and introducing explicit routing via `CommandRouting` (replacing `IsBubblingUp`/`IsBubblingDown`), plus an immutable `CommandContext` with helper `With…` APIs.
> 
> Adds a framework-level composite dispatch mechanism (`View.GetDispatchTarget` + `ConsumeDispatch`) integrated into `RaiseActivating`/`RaiseAccepting`, and migrates composite views (`Shortcut`, `OptionSelector`, `FlagSelector`) to rely on this shared dispatch/consumption behavior instead of bespoke handlers.
> 
> Introduces `CommandBridge` to route `Accept`/`Activate` across non-containment boundaries (used by `MenuBarItem` ↔ `PopoverMenu`), adjusts menu/popover activation/acceptance wiring accordingly, and adds/updates extensive unit + integration tests to cover click/keyboard paths through menus, shortcuts, and selectors (including submenu scenarios).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e1903fe77ee10d141c8a553efad2caead1e27af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->